### PR TITLE
Change guide link

### DIFF
--- a/app/views/preview/new.html.erb
+++ b/app/views/preview/new.html.erb
@@ -4,7 +4,7 @@
 
 			<p><a href="https://github.com/alphagov/govspeak">Govspeak</a> is a simplified 'markup' language based on <a href="http://daringfireball.net/projects/markdown/syntax">Markdown</a>. It's designed to be as easy-to-read and easy-to-write as possible, using simple punctuation instead of complicated tags and code.</p>
 
-			<p>Check out the <a href="https://github.com/alphagov/govspeak/wiki/Using-govspeak-on-GOV.UK">usage docs</a> &ndash; or <a href="/?styleguide=markdown">try</a>, <a href="/?styleguide=govspeak">some</a>, <a href="/?styleguide=sa_outcome">examples</a>.</p>
+			<p>Check out the <a href="http://govspeak-guide.herokuapp.com">usage docs</a> &ndash; or <a href="/?styleguide=markdown">try</a>, <a href="/?styleguide=govspeak">some</a>, <a href="/?styleguide=sa_outcome">examples</a>.</p>
 
 			<form method="post" action="/preview/">
 


### PR DESCRIPTION
We use a guide on heroku now, rather than the github wiki