### PR TITLE
Move govspeak guide into preview app

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ ruby File.read('.ruby-version').chomp
 gem 'rails', '5.1.4'
 gem 'puma'
 gem 'slimmer', '11.1.1'
-gem 'govspeak', '5.2.0'
+gem 'govspeak', '5.2.2'
 gem 'govuk_frontend_toolkit', '7.2.0'
 gem 'rubyzip', '~> 1.2.1'
 gem 'reverse_markdown', '~> 1.0.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,7 +74,7 @@ GEM
     ffi (1.9.18)
     globalid (0.4.0)
       activesupport (>= 4.2.0)
-    govspeak (5.2.0)
+    govspeak (5.2.2)
       actionview (>= 4.1, < 6)
       addressable (>= 2.3.8, < 3)
       commander (~> 4.4)
@@ -252,7 +252,7 @@ PLATFORMS
 DEPENDENCIES
   capybara
   coffee-rails
-  govspeak (= 5.2.0)
+  govspeak (= 5.2.2)
   govuk-lint
   govuk_frontend_toolkit (= 7.2.0)
   listen

--- a/README.md
+++ b/README.md
@@ -4,6 +4,16 @@ A tiny app for previewing and converting [Govspeak](https://github.com/alphagov/
 
 Govspeak is a markdown-derived mark-up language used by [GOV.UK](https://github.com/alphagov).
 
+## Updating the guide
+
+You can find the source files for the guide at [guide.md](app/assets/markdown/guide.md)
+
+This guide is for GOV.UK content designers based at GDS.
+
+It shows how Govspeak looks on the GOV.UK website in mainstream formats.
+
+The guide also says when to use the various types of Govspeak, such as the different callout styles.
+
 ## Deployment
 
 It's hosted on [Heroku](http://govspeak-preview.herokuapp.com/), and automatically deployed when `master` changes.

--- a/app/assets/markdown/guide.md
+++ b/app/assets/markdown/guide.md
@@ -235,6 +235,38 @@ Bradford
 BD98 1YY
 $A
 
+##Buttons
+
+
+To get the most basic button.
+
+    {button}[Continue](https://gov.uk/random){/button}
+
+which looks like this:
+
+{button}[Continue](https://gov.uk/random){/button}
+
+To turn a button into a ['Start now' button](https://www.gov.uk/service-manual/design/start-pages#start-page-elements), you can pass `start` to the button tag.
+These buttons should only appear once per page, and be used at the start of a transaction.
+
+    {button start}[Start Now](https://gov.uk/random){/button}
+
+which looks like this:
+
+{button start}[Start Now](https://gov.uk/random){/button}
+
+You can pass a Google Analytics [tracking id](https://support.google.com/analytics/answer/7372977?hl=en) which will send page views to another domain, this is used to help services understand the start of their users journeys.
+
+    {button start cross-domain-tracking:UA-XXXXXX-Y}
+        [Start Now](https://example.com/external-service/start-now)
+    {/button}
+
+which looks like this:
+
+{button start cross-domain-tracking:UA-XXXXXX-Y}
+  [Start Now](https://example.com/external-service/start-now)
+{/button}
+
 ##Try it yourself
 
 Use the [preview](/) to try using govspeak.

--- a/app/assets/markdown/guide.md
+++ b/app/assets/markdown/guide.md
@@ -238,13 +238,15 @@ $A
 ##Buttons
 
 
-To get the most basic button.
+###Default button
 
     {button}[Continue](https://gov.uk/random){/button}
 
 which looks like this:
 
 {button}[Continue](https://gov.uk/random){/button}
+
+###Start now button
 
 To turn a button into a ['Start now' button](https://www.gov.uk/service-manual/design/start-pages#start-page-elements), you can pass `start` to the button tag.
 These buttons should only appear once per page, and be used at the start of a transaction.
@@ -254,6 +256,8 @@ These buttons should only appear once per page, and be used at the start of a tr
 which looks like this:
 
 {button start}[Start Now](https://gov.uk/random){/button}
+
+###Cross domain tracking button
 
 You can pass a Google Analytics [tracking id](https://support.google.com/analytics/answer/7372977?hl=en) which will send page views to another domain, this is used to help services understand the start of their users journeys.
 

--- a/app/assets/markdown/guide.md
+++ b/app/assets/markdown/guide.md
@@ -1,0 +1,243 @@
+##What is govspeak?
+
+Govspeak is a simplified 'markup' language based on [Markdown](http://daringfireball.net/projects/markdown/syntax). It's designed to be as easy-to-read and easy-to-write as possible, using simple punctuation instead of complicated tags and code.
+
+Govspeak was developed by the [Government Digital Service](digital.cabinetoffice.gov.uk) with some extra features that we use to format content on [GOV.UK.](https://www.gov.uk)
+
+##Headings
+
+You can create heading levels using the hash character (#). The number of hashes shows the heading level.
+
+The top-level headings on a page are automatically formatted as H1, so you don't need to use this.
+
+    ##This is an H2 subheading
+    ###This is an H3 subheading
+
+This is what they look like:
+
+##This is an H2 subheading
+
+###This is an H3 subheading
+
+Don't skip heading levels - in other words, don't jump straight to an H3. Don't insert an H1 anywhere.
+
+##Bold text
+
+    **Double asterisks around text** will turn it bold. Use it sparingly.
+
+This is what it looks like:
+
+**Double asterisks around text** will turn it bold. Use it sparingly.
+
+##Line breaks
+
+To add a line break (a 'soft return', but not a new paragraph), put 2 spaces at the end of a piece of text.
+
+
+##Bulleted lists
+
+Create bulleted lists using asterisks, hyphens or plus signs at the start of each line:
+
+    * asterisk 1
+    * asterisk 2
+    * asterisk 3
+
+    - a hyphen
+    - another hyphen
+
+    + plus signs
+    + more plus signs
+
+This is what they look like:
+
+* asterisk 1
+* asterisk 2
+* asterisk 3
+
+##Lists of steps
+
+We only use numbered lists for describing steps as part of a process. Do this by adding:
+
+`s1. Add numbers.`
+
+`s2. Check numbers.`
+
+`s3. Love numbers.`
+
+This example follows the [style guide](https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#steps) and looks like:
+
+s1. Add numbers.
+s2. Check numbers.
+s3. Love numbers.
+
+Steps need an extra line break after the final step (in other words, 2 full blank lines). If you don't do this, other markdown directly after them won't work. If you have a subheading after numbered steps, add a line break after this.
+
+##Tables
+
+Create tables by separating headings with a `'|'` character. Add a row of hyphens for each column separated by `'|'` character below this. Then use the `'|'` character to separate items in each row:
+
+    Test type | Weekday | Evening, weekend and bank holiday
+    -|-
+    Theory test | 31 | 31
+    Abridged theory | 24 | 24
+    Practical test | 62 | 75
+
+This is what that table looks like on GOV.UK:
+
+Test type | Weekday | Evening, weekend and bank holiday
+-|-
+Theory test | 31 | 31
+Abridged theory | 24 | 24
+Practical test | 62 | 75
+
+##Links
+
+###Internal links
+
+Use the end of the URL path (so https://www.gov.uk/tax-disc would be /tax-disc). The link text goes in square brackets, and the slug goes in standard brackets, with no spaces in between:
+
+    [Renew your tax disc](/tax-disc).
+
+This looks like:
+
+[Renew your tax disc](/tax-disc).
+
+###External links
+
+For external links, you need to include the full URL with http:// or www:
+
+    [UK Parliament](http://www.parliament.uk).
+
+This looks like:
+
+[UK Parliament](http://www.parliament.uk).
+
+###Download links
+
+Use '$D' to place download links in a box that shows users they're going to download a file. Always include the file type and size in brackets as part of the link text and title.
+
+    $D
+    [Download 'Jobcentre Plus form for employment' (PDF, 43KB)](http://example.com/example.pdf)
+    $D
+
+This is what download links look like:
+
+$D
+[Download 'Jobcentre Plus form for employment' (PDF, 43KB)]()
+$D
+
+When linking to PDFs, don't put the trailing slash '/' at the end, as the link won't work.
+
+This is only used for external download files. If the file is hosted on Inside Government, it should link to the splash page as an internal link.
+
+###Email links
+
+    <address@example.com>
+
+This looks like:
+
+<address@example.com>
+
+##Callouts
+
+To draw attention to content, you can use a variety of callouts. For example, you can put some text in an 'information callout' to indicate that it's something related that's worth knowing.
+
+### Information callouts
+
+    ^This is useful information that's worth knowing.^
+
+This looks like:
+
+^This is useful information that's worth knowing.^
+
+### Warning callouts
+
+    %You will be fined or put in prison if you don't do this thing.%
+
+This looks like:
+
+%You will be fined or put in prison if you don't do this thing.%
+
+### Example callout
+
+    $E
+    **Example** Open the pod bay doors.
+    $E
+
+This looks like:
+
+$E
+**Example** Open the pod bay doors.
+$E
+
+##Answer summaries
+
+We no longer add this markdown to any new content. (You may still come across it in the 'quick answer' format.)
+
+  $! This is an answer summary. $!
+
+If you see this markdown, you can delete it.
+
+##Acronyms
+
+List these in the following format at the end of the document and all occurrences will be marked up as acronyms:
+
+    *[FCO]: Foreign and Commonwealth Office
+
+This means the full text will appear when users hover over the acronym wherever it occurs on the page.
+
+###Example of acronym use
+
+Example: PCSO and PCSOs are both in a piece of content.
+
+Always put the longer one first in the list - otherwise PCSOs will pick up only the singular 'Police Community Support Officer'.
+
+    *[PCSOs]: Police Community Support Officers  
+    *[PCSO]: Police Community Support Officer
+
+##Contacts
+
+    $C
+    **Financial Conduct Authority**
+    <consumer.queries@fca.org.uk>
+    Telephone: 0800 111 6768
+    Monday to Friday, 8am to 6pm
+    Saturday, 9am to 1pm
+    [Find out about call charges](/call-charges)
+    $C
+
+Remember to add a call charges link when there are telephone numbers.
+
+This creates a contact box, which looks like this:
+
+$C
+**Financial Conduct Authority**  
+<consumer.queries@fca.org.uk>  
+Telephone: 0800 111 6768  
+Monday to Friday, 8am to 6pm  
+Saturday, 9am to 1pm  
+[Find out about call charges](/call-charges)  
+$C
+
+##Addresses
+
+    $A
+    HM Revenue and Customs
+    Bradford
+    BD98 1YY
+    $A
+
+This creates an address box, which looks like this:
+
+$A
+HM Revenue and Customs
+Bradford
+BD98 1YY
+$A
+
+##Try it yourself
+
+Use the [preview](/) to try using govspeak.
+
+*[PCSOs]: Police Community Support Officers  
+*[PCSO]: Police Community Support Officer

--- a/app/controllers/guide_controller.rb
+++ b/app/controllers/guide_controller.rb
@@ -1,0 +1,9 @@
+class GuideController < ApplicationController
+  def index
+    contents = File.read(File.join(Rails.root, 'app', 'assets', 'markdown', 'guide.md'))
+		@govspeak_doc = Govspeak::Document.new(contents)
+		@govspeak_output = @govspeak_doc.to_html.html_safe
+
+    render :index
+  end
+end

--- a/app/views/guide/index.html.erb
+++ b/app/views/guide/index.html.erb
@@ -1,0 +1,9 @@
+<div class="govspeak-preview-output">
+  <% if (@govspeak_doc && !@govspeak_doc.valid?) %>
+    <p class="validation-warning">This govspeak doesn't validate and may not be accepted by publishing tools</p>
+  <% end %>
+
+  <article>
+    <%= render 'govuk_component/govspeak', content: @govspeak_output %>
+  </article>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,9 +10,9 @@
   <div id="wrapper">
     <ul class="nav">
       <li><%= link_to_unless current_page?(root_path), "Govspeak Preview", root_path %></li>
+      <li><%= link_to_unless current_page?(guide_index_path), "Govspeak Guide", guide_index_path %></li>
       <li><%= link_to_unless current_page?(convert_index_path), "Convert Google Doc to Govspeak", convert_index_path %></li>
     </ul>
-
     <%= yield %>
   </div>
 </body>

--- a/app/views/preview/new.html.erb
+++ b/app/views/preview/new.html.erb
@@ -7,7 +7,7 @@
   </p>
 
   <p>
-    Check out the <a href="http://govspeak-guide.herokuapp.com">usage docs</a>
+    Check out the <a href="/guide">usage docs</a>
     &ndash; or <a href="/?styleguide=markdown">try</a>,
     <a href="/?styleguide=govspeak">some</a>,
     <a href="/?styleguide=sa_outcome">examples</a>.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 Rails.application.routes.draw do
   resources :preview
   resources :convert, only: %w[index create]
+  resources :guide
   root to: 'preview#new'
 end

--- a/spec/features/guide_spec.rb
+++ b/spec/features/guide_spec.rb
@@ -5,9 +5,9 @@ RSpec.feature "Govspeak guide", type: :feature do
     visit "/guide"
 
     expect(page).to have_content("What is govspeak?")
-
-    # Check markdown is turned into a link
-    expect(page).to have_css("a[href="http://www.parliament.uk"]")
     expect(page).to have_content("UK Parliament")
+
+    # Check markdown has rendered button
+    expect(page).to have_content("<p><a role=\\\"button\\\" class=\\\"button button-start\\\" href=\\\"https://example.com/external-service/start-now\\\" data-module=\\\"cross-domain-tracking\\\" data-tracking-code=\\\"UA-XXXXXX-Y\\\" data-tracking-name=\\\"govspeakButtonTracker\\\">Start Now</a></p")
   end
 end

--- a/spec/features/guide_spec.rb
+++ b/spec/features/guide_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+
+RSpec.feature "Govspeak guide", type: :feature do
+  scenario "Govspeak guide renders markdown" do
+    visit "/guide"
+
+    expect(page).to have_content("What is govspeak?")
+
+    # Check markdown is turned into a link
+    expect(page).to have_css("a[href="http://www.parliament.uk"]")
+    expect(page).to have_content("UK Parliament")
+  end
+end


### PR DESCRIPTION
Moves the govspeak-guide content into this repo, this is more up to date and we can retire the old version.

We tried to update the old application but it'd require a rails upgrade so we want to retire it instead.

https://github.com/alphagov/govspeak-guide

https://trello.com/c/ppqXaGPk/122-create-a-govspeak-component-for-buttons
