### PR TITLE
Revert "Bump uglifier from 3.2.0 to 4.0.1"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -236,7 +236,7 @@ GEM
     tilt (2.0.8)
     tzinfo (1.2.4)
       thread_safe (~> 0.1)
-    uglifier (4.0.1)
+    uglifier (3.2.0)
       execjs (>= 0.3.0, < 3)
     unf (0.1.4)
       unf_ext


### PR DESCRIPTION
Reverts alphagov/govspeak-preview#25

This was breaking deployment - similar to other apps that had this problem.