### PR TITLE
Remove dependency on static

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,6 @@ ruby File.read('.ruby-version').chomp
 
 gem 'rails', '5.2.3'
 gem 'puma'
-gem 'slimmer', '13.0.0'
 gem 'govspeak'
 gem 'govuk_frontend_toolkit', '7.2.0'
 gem 'govuk_publishing_components'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,7 +125,6 @@ GEM
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.3)
-    json (2.2.0)
     kgio (2.11.2)
     kramdown (1.15.0)
     link_header (0.0.8)
@@ -276,14 +275,6 @@ GEM
       sass (~> 3.5, >= 3.5.5)
     sentry-raven (2.11.1)
       faraday (>= 0.7.6, < 1.0)
-    slimmer (13.0.0)
-      activesupport
-      json
-      nokogiri (~> 1.7)
-      null_logger
-      plek (>= 1.1.0)
-      rack
-      rest-client
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -334,7 +325,6 @@ DEPENDENCIES
   rspec-rails (~> 3.7)
   rubyzip (~> 1.3.0)
   sass-rails (~> 5.1)
-  slimmer (= 13.0.0)
   uglifier
   webmock (~> 3.3.0)
 

--- a/app.json
+++ b/app.json
@@ -15,7 +15,6 @@
     "RAILS_ENV": {
       "required": true
     },
-    "PLEK_SERVICE_STATIC_URI": "assets.publishing.service.gov.uk",
     "GOVUK_APP_DOMAIN": "www.gov.uk",
     "GOVUK_WEBSITE_ROOT": "https://www.gov.uk"
   },

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,75 +1,29 @@
-$govuk-compatibility-govuktemplate: true;
-
-@import "grid_layout";
-@import "typography";
-@import "design-patterns/buttons";
 @import "govuk_publishing_components/all_components";
 
-#global-header-bar,
-#global-breadcrumb,
-#global-cookie-message,
-#user-satisfaction-survey,
-#search {
-  display: none !important;
-}
-
-.submit-button {
-  @include button;
-}
-
-.nav {
-  margin: $gutter/2 0;
-
-  li {
-    margin-right: $gutter/2;
-    display: inline-block;
-  }
-}
-
-.header-logo {
-  a {
-    display: none;
-  }
-
-  &:after {
-    content: "Govspeak Preview" !important;
-    height: 30px;
-    width: 100%;
-    margin: 0 15px;
-    font-weight: bold;
-    font-size: 30px;
-    color: #fff;
-    line-height: 1;
-  }
-}
-
-.outer-block {
-  @include outer-block;
-}
-
-.inner-block {
-  @include inner-block;
+body {
+  margin: 0;
 }
 
 .govspeak-preview-input {
-  background: #f6f6f6;
+  @include govuk-font(19);
+  background: govuk-colour('light-grey');
   padding: 2em;
-  @include core-19;
+  margin-top: govuk-spacing(4);
 
   p {
-    margin-bottom: $gutter / 2;
+    margin-bottom: govuk-spacing(3);
   }
 
   textarea {
     width: 100%;
     height: 10em;
-    margin-bottom: $gutter / 2;
+    margin-bottom: govuk-spacing(3);
   }
 }
 
 
 .govspeak-preview-output {
-  border-top: 1px solid #aaa;
+  border-top: 1px solid $govuk-border-colour;
   padding: 2em 0;
 
   .inner-block {
@@ -84,16 +38,16 @@ $govuk-compatibility-govuktemplate: true;
 .govspeak-guide {
   .code-snippet + p,
   pre {
+    @include govuk-font(16);
     overflow-x: auto;
     max-width: 100%;
     position: relative;
     display: inline-block;
     box-sizing: border-box;
-    padding: $gutter / 2;
-    border: 4px solid $grey-3;
+    padding: govuk-spacing(3);
+    border: 4px solid govuk-colour("light-grey");
     padding-top: 2.2em;
     margin: 0;
-    font-size: 16px;
 
     &::before {
       content: 'govspeak';
@@ -102,18 +56,18 @@ $govuk-compatibility-govuktemplate: true;
       top: 0;
       padding-left: .5em;
       padding-right: .5em;
-      background: $grey-3;
+      background: govuk-colour("light-grey");
     }
   }
 
   h2 + pre,
   h3 + pre {
-    margin-top: $gutter / 2;
+    margin-top: govuk-spacing(3);
   }
 }
 
 .validation-warning {
-  background: red;
-  color: #fff;
+  background: $govuk-error-colour;
+  color: govuk-colour("white");
   padding: .5em 1em;
 }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,3 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery
-
-  include Slimmer::Headers
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,19 @@
 module ApplicationHelper
+  def navigation_items
+    items = []
+
+    items << { text: "Govspeak Preview", href: "/", active: is_current?("/") }
+    items << { text: "Govspeak Guide", href: "/guide", active: is_current?("/guide") }
+    items << { text: "Convert Google Doc to Govspeak", href: "/convert", active: is_current?("/convert") }
+
+    items
+  end
+
+private
+
+  def is_current?(link)
+    recognized = Rails.application.routes.recognize_path(link)
+    recognized[:controller] == params[:controller] &&
+      recognized[:action] == params[:action]
+  end
 end

--- a/app/views/convert/index.html.erb
+++ b/app/views/convert/index.html.erb
@@ -1,10 +1,10 @@
 <div class="govspeak-preview-input">
   <p>
-    Converts Google Docs into <a href="https://github.com/alphagov/govspeak">Govspeak</a> ready for Specialist Publisher.<br/>
+    Converts Google Docs into <a href="https://github.com/alphagov/govspeak" class="govuk-link">Govspeak</a> ready for Specialist Publisher.<br/>
   </p>
 
   <p>
-    To download the file, go to Google Docs and click <%= link_to "File > Download as > Web page (.html, zipped)", image_url("govspeak-preview.gif") %>
+    To download the file, go to Google Docs and click <%= link_to "File > Download as > Web page (.html, zipped)", image_url("govspeak-preview.gif"), class: "govuk-link" %>
   </p>
 
   <%= form_tag({ action: :create }, multipart: true) do %>

--- a/app/views/convert/index.html.erb
+++ b/app/views/convert/index.html.erb
@@ -9,16 +9,29 @@
 
   <%= form_tag({ action: :create }, multipart: true) do %>
     <label for="govspeak_input"></label>
-    <%= file_field_tag "upload[file]" %>
-    <input type="submit" class="submit-button" value="Convert" />
+    <%= render "govuk_publishing_components/components/file_upload", {
+      label: {
+        text: "Upload a file"
+      },
+      name: "upload[file]"
+    } %>
+    <%= render "govuk_publishing_components/components/button", {
+      text: "Convert",
+    } %>
   <% end %>
 </div>
 
 <% if @govspeak_input %>
 <div class="govspeak-preview-input">
   <form>
-    <label for="govspeak_input">Converted Govspeak:</label>
-    <textarea id="govspeak_input" name="govspeak"><%= @govspeak_input %></textarea>
+    <%= render "govuk_publishing_components/components/textarea", {
+      label: {
+        text: "Converted govspeak:"
+      },
+      id: "govspeak_input",
+      name: "govspeak",
+      value: @govspeak_input
+    } %>
   </form>
 </div>
 <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,12 +8,51 @@
 </head>
 <body>
   <div id="wrapper">
-    <ul class="nav">
-      <li><%= link_to_unless current_page?(root_path), "Govspeak Preview", root_path %></li>
-      <li><%= link_to_unless current_page?(guide_index_path), "Govspeak Guide", guide_index_path %></li>
-      <li><%= link_to_unless current_page?(convert_index_path), "Convert Google Doc to Govspeak", convert_index_path %></li>
-    </ul>
-    <%= yield %>
+    <header class="govuk-header " role="banner" data-module="govuk-header">
+      <div class="govuk-header__container govuk-width-container">
+        <div class="govuk-header__logo">
+          <a href="#" class="govuk-header__link govuk-header__link--homepage">
+            <span class="govuk-header__logotype">
+              <svg role="presentation" focusable="false" class="govuk-header__logotype-crown" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 132 97" height="30" width="36">
+                <path fill="currentColor" fill-rule="evenodd" d="M25 30.2c3.5 1.5 7.7-.2 9.1-3.7 1.5-3.6-.2-7.8-3.9-9.2-3.6-1.4-7.6.3-9.1 3.9-1.4 3.5.3 7.5 3.9 9zM9 39.5c3.6 1.5 7.8-.2 9.2-3.7 1.5-3.6-.2-7.8-3.9-9.1-3.6-1.5-7.6.2-9.1 3.8-1.4 3.5.3 7.5 3.8 9zM4.4 57.2c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.5-1.5-7.6.3-9.1 3.8-1.4 3.5.3 7.6 3.9 9.1zm38.3-21.4c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.6-1.5-7.6.3-9.1 3.8-1.3 3.6.4 7.7 3.9 9.1zm64.4-5.6c-3.6 1.5-7.8-.2-9.1-3.7-1.5-3.6.2-7.8 3.8-9.2 3.6-1.4 7.7.3 9.2 3.9 1.3 3.5-.4 7.5-3.9 9zm15.9 9.3c-3.6 1.5-7.7-.2-9.1-3.7-1.5-3.6.2-7.8 3.7-9.1 3.6-1.5 7.7.2 9.2 3.8 1.5 3.5-.3 7.5-3.8 9zm4.7 17.7c-3.6 1.5-7.8-.2-9.2-3.8-1.5-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.3 3.5-.4 7.6-3.9 9.1zM89.3 35.8c-3.6 1.5-7.8-.2-9.2-3.8-1.4-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.4 3.6-.3 7.7-3.9 9.1zM69.7 17.7l8.9 4.7V9.3l-8.9 2.8c-.2-.3-.5-.6-.9-.9L72.4 0H59.6l3.5 11.2c-.3.3-.6.5-.9.9l-8.8-2.8v13.1l8.8-4.7c.3.3.6.7.9.9l-5 15.4v.1c-.2.8-.4 1.6-.4 2.4 0 4.1 3.1 7.5 7 8.1h.2c.3 0 .7.1 1 .1.4 0 .7 0 1-.1h.2c4-.6 7.1-4.1 7.1-8.1 0-.8-.1-1.7-.4-2.4V34l-5.1-15.4c.4-.2.7-.6 1-.9zM66 92.8c16.9 0 32.8 1.1 47.1 3.2 4-16.9 8.9-26.7 14-33.5l-9.6-3.4c1 4.9 1.1 7.2 0 10.2-1.5-1.4-3-4.3-4.2-8.7L108.6 76c2.8-2 5-3.2 7.5-3.3-4.4 9.4-10 11.9-13.6 11.2-4.3-.8-6.3-4.6-5.6-7.9 1-4.7 5.7-5.9 8-.5 4.3-8.7-3-11.4-7.6-8.8 7.1-7.2 7.9-13.5 2.1-21.1-8 6.1-8.1 12.3-4.5 20.8-4.7-5.4-12.1-2.5-9.5 6.2 3.4-5.2 7.9-2 7.2 3.1-.6 4.3-6.4 7.8-13.5 7.2-10.3-.9-10.9-8-11.2-13.8 2.5-.5 7.1 1.8 11 7.3L80.2 60c-4.1 4.4-8 5.3-12.3 5.4 1.4-4.4 8-11.6 8-11.6H55.5s6.4 7.2 7.9 11.6c-4.2-.1-8-1-12.3-5.4l1.4 16.4c3.9-5.5 8.5-7.7 10.9-7.3-.3 5.8-.9 12.8-11.1 13.8-7.2.6-12.9-2.9-13.5-7.2-.7-5 3.8-8.3 7.1-3.1 2.7-8.7-4.6-11.6-9.4-6.2 3.7-8.5 3.6-14.7-4.6-20.8-5.8 7.6-5 13.9 2.2 21.1-4.7-2.6-11.9.1-7.7 8.8 2.3-5.5 7.1-4.2 8.1.5.7 3.3-1.3 7.1-5.7 7.9-3.5.7-9-1.8-13.5-11.2 2.5.1 4.7 1.3 7.5 3.3l-4.7-15.4c-1.2 4.4-2.7 7.2-4.3 8.7-1.1-3-.9-5.3 0-10.2l-9.5 3.4c5 6.9 9.9 16.7 14 33.5 14.8-2.1 30.8-3.2 47.7-3.2z"></path>
+                <image src="/assets/images/govuk-logotype-crown.png" xlink:href="" class="govuk-header__logotype-crown-fallback-image" width="36" height="32"></image>
+              </svg>
+              <span class="govuk-header__logotype-text">
+                GOV.UK
+              </span>
+            </span>
+          </a>
+        </div>
+        <div class="govuk-header__content">
+          <a href="/" class="govuk-header__link govuk-header__link--service-name">
+            Govspeak Preview
+          </a>
+          <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
+          <nav>
+            <ul id="navigation" class="govuk-header__navigation " aria-label="Top Level Navigation">
+              <li class="govuk-header__navigation-item">
+                <a class="govuk-header__link" href="/">
+                  Govspeak Preview
+                </a>
+              </li>
+              <li class="govuk-header__navigation-item govuk-header__navigation-item">
+                <a class="govuk-header__link" href="/guide">
+                  Govspeak Guide
+                </a>
+              </li>
+              <li class="govuk-header__navigation-item">
+                <a class="govuk-header__link" href="/convert">
+                  Convert Google Doc to Govspeak
+                </a>
+              </li>
+            </ul>
+          </nav>
+        </div>
+      </div>
+    </header>
+    <main class="govuk-width-container">
+      <%= yield %>
+    </main>
   </div>
 </body>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,48 +8,11 @@
 </head>
 <body>
   <div id="wrapper">
-    <header class="govuk-header " role="banner" data-module="govuk-header">
-      <div class="govuk-header__container govuk-width-container">
-        <div class="govuk-header__logo">
-          <a href="#" class="govuk-header__link govuk-header__link--homepage">
-            <span class="govuk-header__logotype">
-              <svg role="presentation" focusable="false" class="govuk-header__logotype-crown" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 132 97" height="30" width="36">
-                <path fill="currentColor" fill-rule="evenodd" d="M25 30.2c3.5 1.5 7.7-.2 9.1-3.7 1.5-3.6-.2-7.8-3.9-9.2-3.6-1.4-7.6.3-9.1 3.9-1.4 3.5.3 7.5 3.9 9zM9 39.5c3.6 1.5 7.8-.2 9.2-3.7 1.5-3.6-.2-7.8-3.9-9.1-3.6-1.5-7.6.2-9.1 3.8-1.4 3.5.3 7.5 3.8 9zM4.4 57.2c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.5-1.5-7.6.3-9.1 3.8-1.4 3.5.3 7.6 3.9 9.1zm38.3-21.4c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.6-1.5-7.6.3-9.1 3.8-1.3 3.6.4 7.7 3.9 9.1zm64.4-5.6c-3.6 1.5-7.8-.2-9.1-3.7-1.5-3.6.2-7.8 3.8-9.2 3.6-1.4 7.7.3 9.2 3.9 1.3 3.5-.4 7.5-3.9 9zm15.9 9.3c-3.6 1.5-7.7-.2-9.1-3.7-1.5-3.6.2-7.8 3.7-9.1 3.6-1.5 7.7.2 9.2 3.8 1.5 3.5-.3 7.5-3.8 9zm4.7 17.7c-3.6 1.5-7.8-.2-9.2-3.8-1.5-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.3 3.5-.4 7.6-3.9 9.1zM89.3 35.8c-3.6 1.5-7.8-.2-9.2-3.8-1.4-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.4 3.6-.3 7.7-3.9 9.1zM69.7 17.7l8.9 4.7V9.3l-8.9 2.8c-.2-.3-.5-.6-.9-.9L72.4 0H59.6l3.5 11.2c-.3.3-.6.5-.9.9l-8.8-2.8v13.1l8.8-4.7c.3.3.6.7.9.9l-5 15.4v.1c-.2.8-.4 1.6-.4 2.4 0 4.1 3.1 7.5 7 8.1h.2c.3 0 .7.1 1 .1.4 0 .7 0 1-.1h.2c4-.6 7.1-4.1 7.1-8.1 0-.8-.1-1.7-.4-2.4V34l-5.1-15.4c.4-.2.7-.6 1-.9zM66 92.8c16.9 0 32.8 1.1 47.1 3.2 4-16.9 8.9-26.7 14-33.5l-9.6-3.4c1 4.9 1.1 7.2 0 10.2-1.5-1.4-3-4.3-4.2-8.7L108.6 76c2.8-2 5-3.2 7.5-3.3-4.4 9.4-10 11.9-13.6 11.2-4.3-.8-6.3-4.6-5.6-7.9 1-4.7 5.7-5.9 8-.5 4.3-8.7-3-11.4-7.6-8.8 7.1-7.2 7.9-13.5 2.1-21.1-8 6.1-8.1 12.3-4.5 20.8-4.7-5.4-12.1-2.5-9.5 6.2 3.4-5.2 7.9-2 7.2 3.1-.6 4.3-6.4 7.8-13.5 7.2-10.3-.9-10.9-8-11.2-13.8 2.5-.5 7.1 1.8 11 7.3L80.2 60c-4.1 4.4-8 5.3-12.3 5.4 1.4-4.4 8-11.6 8-11.6H55.5s6.4 7.2 7.9 11.6c-4.2-.1-8-1-12.3-5.4l1.4 16.4c3.9-5.5 8.5-7.7 10.9-7.3-.3 5.8-.9 12.8-11.1 13.8-7.2.6-12.9-2.9-13.5-7.2-.7-5 3.8-8.3 7.1-3.1 2.7-8.7-4.6-11.6-9.4-6.2 3.7-8.5 3.6-14.7-4.6-20.8-5.8 7.6-5 13.9 2.2 21.1-4.7-2.6-11.9.1-7.7 8.8 2.3-5.5 7.1-4.2 8.1.5.7 3.3-1.3 7.1-5.7 7.9-3.5.7-9-1.8-13.5-11.2 2.5.1 4.7 1.3 7.5 3.3l-4.7-15.4c-1.2 4.4-2.7 7.2-4.3 8.7-1.1-3-.9-5.3 0-10.2l-9.5 3.4c5 6.9 9.9 16.7 14 33.5 14.8-2.1 30.8-3.2 47.7-3.2z"></path>
-                <image src="/assets/images/govuk-logotype-crown.png" xlink:href="" class="govuk-header__logotype-crown-fallback-image" width="36" height="32"></image>
-              </svg>
-              <span class="govuk-header__logotype-text">
-                GOV.UK
-              </span>
-            </span>
-          </a>
-        </div>
-        <div class="govuk-header__content">
-          <a href="/" class="govuk-header__link govuk-header__link--service-name">
-            Govspeak Preview
-          </a>
-          <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
-          <nav>
-            <ul id="navigation" class="govuk-header__navigation " aria-label="Top Level Navigation">
-              <li class="govuk-header__navigation-item">
-                <a class="govuk-header__link" href="/">
-                  Govspeak Preview
-                </a>
-              </li>
-              <li class="govuk-header__navigation-item govuk-header__navigation-item">
-                <a class="govuk-header__link" href="/guide">
-                  Govspeak Guide
-                </a>
-              </li>
-              <li class="govuk-header__navigation-item">
-                <a class="govuk-header__link" href="/convert">
-                  Convert Google Doc to Govspeak
-                </a>
-              </li>
-            </ul>
-          </nav>
-        </div>
-      </div>
-    </header>
+    <%= render "govuk_publishing_components/components/layout_header", {
+      environment: "example",
+      product_name: "Govspeak Preview",
+      navigation_items: navigation_items
+    } %>
     <main class="govuk-width-container">
       <%= yield %>
     </main>

--- a/app/views/preview/new.html.erb
+++ b/app/views/preview/new.html.erb
@@ -1,16 +1,16 @@
 <div class="govspeak-preview-input">
   <p>
-    <a href="https://github.com/alphagov/govspeak">Govspeak</a> is a simplified 'markup' language based on
-    <a href="http://daringfireball.net/projects/markdown/syntax">Markdown</a>.
+    <a href="https://github.com/alphagov/govspeak" class="govuk-link">Govspeak</a> is a simplified 'markup' language based on
+    <a href="http://daringfireball.net/projects/markdown/syntax" class="govuk-link">Markdown</a>.
     It's designed to be as easy-to-read and easy-to-write as possible, using
     simple punctuation instead of complicated tags and code.
   </p>
 
   <p>
-    Check out the <a href="/guide">usage docs</a>
-    &ndash; or <a href="/?styleguide=markdown">try</a>,
-    <a href="/?styleguide=govspeak">some</a>,
-    <a href="/?styleguide=sa_outcome">examples</a>.
+    Check out the <a href="/guide" class="govuk-link">usage docs</a>
+    &ndash; or <a href="/?styleguide=markdown" class="govuk-link">try</a>,
+    <a href="/?styleguide=govspeak" class="govuk-link">some</a>,
+    <a href="/?styleguide=sa_outcome" class="govuk-link">examples</a>.
   </p>
 
   <form method="post" action="/preview/">

--- a/app/views/preview/new.html.erb
+++ b/app/views/preview/new.html.erb
@@ -14,9 +14,17 @@
   </p>
 
   <form method="post" action="/preview/">
-    <label for="govspeak_input"></label>
-    <textarea id="govspeak_input" name="govspeak"><%= @govspeak_input %></textarea>
-    <input type="submit" class="submit-button" value="Preview it" />
+    <%= render "govuk_publishing_components/components/textarea", {
+      label: {
+        text: "Enter govspeak to preview:"
+      },
+      id: "govspeak_input",
+      name: "govspeak",
+      value: @govspeak_input
+    } %>
+    <%= render "govuk_publishing_components/components/button", {
+      text: "Preview",
+    } %>
   </form>
 </div>
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -10,8 +10,6 @@ require 'rspec/rails'
 require 'webmock/rspec'
 WebMock.disable_net_connect!
 
-require 'slimmer/test'
-
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
 # run as spec files by default. This means that files in spec/support that end

--- a/startup.sh
+++ b/startup.sh
@@ -5,7 +5,6 @@ bundle install
 if [[ $1 == "--live" ]] ; then
   GOVUK_APP_DOMAIN=www.gov.uk \
   GOVUK_WEBSITE_ROOT=https://www.gov.uk \
-  PLEK_SERVICE_STATIC_URI=${PLEK_SERVICE_STATIC_URI-assets.publishing.service.gov.uk} \
   bundle exec rails s -p 3000
 else
   bundle exec rails s -p 3000


### PR DESCRIPTION
## What
We found out that this app had a reliance on Static and Slimmer, which probably shouldn't be the case. This PR:

- removes reliance on static and slimmer
- remove govuk-frontend-toolkit
- replaces elements with components and removes unnecessary CSS
- removes the footer

## Why

- There's no reason why this app should be relying on Static
- We're in the process of making large changes to Static and trying to move as much out of it as possible - this seems like something which could be easily missed and could break as a result of our changes in the future.

Heroku app: https://govspeak-pre-remove-sta-dvoph5.herokuapp.com/

## Before
<img width="1024" alt="Screenshot 2020-02-05 at 14 48 15" src="https://user-images.githubusercontent.com/29889908/73852112-8ecd5580-4826-11ea-8ec4-22fb38dc87dd.png">
<img width="1013" alt="Screenshot 2020-02-05 at 14 48 41" src="https://user-images.githubusercontent.com/29889908/73852168-a573ac80-4826-11ea-8b3e-7eb212bb0a17.png">
<img width="1012" alt="Screenshot 2020-02-05 at 14 48 50" src="https://user-images.githubusercontent.com/29889908/73852171-a6a4d980-4826-11ea-83dd-d8c6bc0e3d72.png">

## After
<img width="1001" alt="Screenshot 2020-02-05 at 14 49 35" src="https://user-images.githubusercontent.com/29889908/73852235-c50ad500-4826-11ea-95a3-343fbbc28f05.png">
<img width="997" alt="Screenshot 2020-02-05 at 14 49 40" src="https://user-images.githubusercontent.com/29889908/73852237-c5a36b80-4826-11ea-891b-0c1624b75fac.png">
<img width="1013" alt="Screenshot 2020-02-05 at 14 49 44" src="https://user-images.githubusercontent.com/29889908/73852238-c5a36b80-4826-11ea-900c-5df0301ddfe8.png">
