### PR TITLE
Use `rubocop-govuk` instead of `govuk-lint`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,4 @@
+inherit_gem:
+  rubocop-govuk:
+    - config/default.yml
+    - config/rails.yml

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,3 +2,9 @@ inherit_gem:
   rubocop-govuk:
     - config/default.yml
     - config/rails.yml
+
+# The description doesn't tell us to explicitly do anything:
+# "Tagging a string as html safe may be a security risk."
+# So let's ignore it for now.
+Rails/OutputSafety:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,10 @@ inherit_gem:
     - config/default.yml
     - config/rails.yml
 
+Style/ExpandPathArguments:
+  Exclude:
+    - 'spec/rails_helper.rb' # Automatically generated
+
 # The description doesn't tell us to explicitly do anything:
 # "Tagging a string as html safe may be a security risk."
 # So let's ignore it for now.

--- a/Gemfile
+++ b/Gemfile
@@ -1,29 +1,29 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
-ruby File.read('.ruby-version').chomp
+ruby File.read(".ruby-version").chomp
 
-gem 'gds-api-adapters'
-gem 'govspeak'
-gem 'govuk_frontend_toolkit', '7.2.0'
-gem 'govuk_publishing_components', '~> 21'
-gem 'puma'
-gem 'rails', '5.2.3'
-gem 'reverse_markdown', '~> 1.0.5'
-gem 'rubyzip', '~> 1.3.0'
+gem "gds-api-adapters"
+gem "govspeak"
+gem "govuk_frontend_toolkit", "7.2.0"
+gem "govuk_publishing_components", "~> 21"
+gem "puma"
+gem "rails", "5.2.3"
+gem "reverse_markdown", "~> 1.0.5"
+gem "rubyzip", "~> 1.3.0"
 
 group :assets do
-  gem 'coffee-rails'
-  gem 'sass-rails', '~> 5.1'
-  gem 'uglifier'
+  gem "coffee-rails"
+  gem "sass-rails", "~> 5.1"
+  gem "uglifier"
 end
 
 group :development, :test do
-  gem 'capybara'
-  gem 'listen'
-  gem 'rspec-rails', '~> 3.7'
-  gem 'rubocop-govuk'
+  gem "capybara"
+  gem "listen"
+  gem "rspec-rails", "~> 3.7"
+  gem "rubocop-govuk"
 end
 
 group :test do
-  gem 'webmock', '~> 3.3.0'
+  gem "webmock", "~> 3.3.0"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ group :development, :test do
   gem 'listen'
   gem 'rspec-rails', '~> 3.7'
   gem 'capybara'
-  gem 'govuk-lint'
+  gem 'rubocop-govuk'
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -2,25 +2,25 @@ source 'https://rubygems.org'
 
 ruby File.read('.ruby-version').chomp
 
-gem 'rails', '5.2.3'
-gem 'puma'
+gem 'gds-api-adapters'
 gem 'govspeak'
 gem 'govuk_frontend_toolkit', '7.2.0'
 gem 'govuk_publishing_components', '~> 21'
-gem 'rubyzip', '~> 1.3.0'
+gem 'puma'
+gem 'rails', '5.2.3'
 gem 'reverse_markdown', '~> 1.0.5'
-gem 'gds-api-adapters'
+gem 'rubyzip', '~> 1.3.0'
 
 group :assets do
-  gem 'sass-rails', '~> 5.1'
   gem 'coffee-rails'
+  gem 'sass-rails', '~> 5.1'
   gem 'uglifier'
 end
 
 group :development, :test do
+  gem 'capybara'
   gem 'listen'
   gem 'rspec-rails', '~> 3.7'
-  gem 'capybara'
   gem 'rubocop-govuk'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,11 +94,6 @@ GEM
       nokogumbo (~> 2)
       rinku (~> 2.0)
       sanitize (~> 5)
-    govuk-lint (4.3.0)
-      rubocop (~> 0.76)
-      rubocop-rails (~> 2)
-      rubocop-rspec (~> 1.28)
-      scss_lint
     govuk_app_config (2.0.3)
       logstasher (>= 1.2.2, < 1.4.0)
       sentry-raven (>= 2.7.1, < 2.14.0)
@@ -160,7 +155,7 @@ GEM
       nokogiri (~> 1.8, >= 1.8.4)
     null_logger (0.0.1)
     parallel (1.19.1)
-    parser (2.7.0.2)
+    parser (2.7.0.4)
       ast (~> 2.4.0)
     plek (3.0.0)
     public_suffix (4.0.3)
@@ -230,17 +225,21 @@ GEM
       rspec-mocks (~> 3.9.0)
       rspec-support (~> 3.9.0)
     rspec-support (3.9.2)
-    rubocop (0.79.0)
+    rubocop (0.77.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
-      parser (>= 2.7.0.1)
+      parser (>= 2.6)
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.7)
+    rubocop-govuk (2.0.0)
+      rubocop (= 0.77)
+      rubocop-rails (~> 2)
+      rubocop-rspec (~> 1.28)
     rubocop-rails (2.4.2)
       rack (>= 1.1)
       rubocop (>= 0.72.0)
-    rubocop-rspec (1.37.1)
+    rubocop-rspec (1.38.1)
       rubocop (>= 0.68.1)
     ruby-progressbar (1.10.1)
     rubyzip (1.3.0)
@@ -268,8 +267,6 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    scss_lint (0.59.0)
-      sass (~> 3.5, >= 3.5.5)
     sentry-raven (2.13.0)
       faraday (>= 0.7.6, < 1.0)
     sprockets (3.7.2)
@@ -312,7 +309,6 @@ DEPENDENCIES
   coffee-rails
   gds-api-adapters
   govspeak
-  govuk-lint
   govuk_frontend_toolkit (= 7.2.0)
   govuk_publishing_components (~> 21)
   listen
@@ -320,6 +316,7 @@ DEPENDENCIES
   rails (= 5.2.3)
   reverse_markdown (~> 1.0.5)
   rspec-rails (~> 3.7)
+  rubocop-govuk
   rubyzip (~> 1.3.0)
   sass-rails (~> 5.1)
   uglifier

--- a/app/controllers/convert_controller.rb
+++ b/app/controllers/convert_controller.rb
@@ -1,6 +1,5 @@
 class ConvertController < ApplicationController
-  def index
-  end
+  def index; end
 
   def create
     @govspeak_input = GoogleDocsToGovspeak.new(params[:upload][:file]).to_govspeak

--- a/app/controllers/guide_controller.rb
+++ b/app/controllers/guide_controller.rb
@@ -1,6 +1,6 @@
 class GuideController < ApplicationController
   def index
-    contents = File.read(File.join(Rails.root, "app", "assets", "markdown", "guide.md"))
+    contents = File.read(Rails.root.join("app/assets/markdown/guide.md"))
     @govspeak_doc = Govspeak::Document.new(contents)
     @govspeak_output = @govspeak_doc.to_html.html_safe
 

--- a/app/controllers/guide_controller.rb
+++ b/app/controllers/guide_controller.rb
@@ -1,6 +1,6 @@
 class GuideController < ApplicationController
   def index
-    contents = File.read(File.join(Rails.root, 'app', 'assets', 'markdown', 'guide.md'))
+    contents = File.read(File.join(Rails.root, "app", "assets", "markdown", "guide.md"))
     @govspeak_doc = Govspeak::Document.new(contents)
     @govspeak_output = @govspeak_doc.to_html.html_safe
 

--- a/app/controllers/guide_controller.rb
+++ b/app/controllers/guide_controller.rb
@@ -1,8 +1,8 @@
 class GuideController < ApplicationController
   def index
     contents = File.read(File.join(Rails.root, 'app', 'assets', 'markdown', 'guide.md'))
-		@govspeak_doc = Govspeak::Document.new(contents)
-		@govspeak_output = @govspeak_doc.to_html.html_safe
+    @govspeak_doc = Govspeak::Document.new(contents)
+    @govspeak_output = @govspeak_doc.to_html.html_safe
 
     render :index
   end

--- a/app/controllers/preview_controller.rb
+++ b/app/controllers/preview_controller.rb
@@ -1,9 +1,9 @@
-require 'govspeak'
+require "govspeak"
 
 class PreviewController < ApplicationController
   def new
     if params[:styleguide]
-      styleguides = YAML.load(File.read(File.expand_path('lib/styleguides.yml'))).with_indifferent_access
+      styleguides = YAML.load(File.read(File.expand_path("lib/styleguides.yml"))).with_indifferent_access
       @govspeak_input = styleguides[params[:styleguide]]
     else
       @govspeak_input = params[:govspeak]

--- a/app/controllers/preview_controller.rb
+++ b/app/controllers/preview_controller.rb
@@ -3,7 +3,7 @@ require "govspeak"
 class PreviewController < ApplicationController
   def new
     if params[:styleguide]
-      styleguides = YAML.load(File.read(File.expand_path("lib/styleguides.yml"))).with_indifferent_access
+      styleguides = YAML.safe_load(File.read(File.expand_path("lib/styleguides.yml"))).with_indifferent_access
       @govspeak_input = styleguides[params[:styleguide]]
     else
       @govspeak_input = params[:govspeak]

--- a/app/services/google_docs_to_govspeak.rb
+++ b/app/services/google_docs_to_govspeak.rb
@@ -1,4 +1,4 @@
-require 'zip'
+require "zip"
 
 class GoogleDocsToGovspeak
   def initialize(uploaded_file)
@@ -12,14 +12,14 @@ class GoogleDocsToGovspeak
     strip_google_tracking_links(doc)
 
     # Strip everything except the body
-    body_html = doc.css('body')
+    body_html = doc.css("body")
 
     markdown = ReverseMarkdown.convert(body_html.to_s)
 
     # The resulting markdown can sometimes contain &nbsp;'s. Translate them
     # into spaces and make sure that we don't have too many.
-    markdown.gsub!('&nbsp;', ' ')
-    markdown.gsub!('  ', ' ')
+    markdown.gsub!("&nbsp;", " ")
+    markdown.gsub!("  ", " ")
 
     markdown
   end
@@ -42,21 +42,21 @@ private
   # Remove the paragraphs inside table cells, otherwise the converter will
   # put in line breaks that will break the table layout.
   def strip_paragraphs_from_tables(doc)
-    doc.css('td p').each { |node| node.replace(node.children) }
+    doc.css("td p").each { |node| node.replace(node.children) }
   end
 
   # Google exports HTML with the links wrapped in a tracking URL like
   # https://www.google.com/url?q=THE_URRL&sa=D&ust=12312&usg=AFQjCN...
   # This removes them.
   def strip_google_tracking_links(doc)
-    doc.css('a').each do |node|
-      href = node.attr('href').to_s
+    doc.css("a").each do |node|
+      href = node.attr("href").to_s
       next unless href.present?
 
       query_string = URI.parse(href).query
-      actual_url = Rack::Utils.parse_nested_query(query_string)['q']
+      actual_url = Rack::Utils.parse_nested_query(query_string)["q"]
 
-      node['href'] = actual_url
+      node["href"] = actual_url
     end
   end
 end

--- a/app/services/google_docs_to_govspeak.rb
+++ b/app/services/google_docs_to_govspeak.rb
@@ -51,7 +51,7 @@ private
   def strip_google_tracking_links(doc)
     doc.css("a").each do |node|
       href = node.attr("href").to_s
-      next unless href.present?
+      next if href.blank?
 
       query_string = URI.parse(href).query
       actual_url = Rack::Utils.parse_nested_query(query_string)["q"]

--- a/spec/features/govspeak_preview_spec.rb
+++ b/spec/features/govspeak_preview_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.feature "Previews", type: :feature do
   scenario "user clicks on 'some' styleguide example and sees example govspeak" do
@@ -14,6 +14,6 @@ RSpec.feature "Previews", type: :feature do
 
     click_on "Preview"
 
-    expect(page).to have_content('This is an information callout')
+    expect(page).to have_content("This is an information callout")
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,13 +1,13 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
-ENV['RAILS_ENV'] ||= 'test'
-require File.expand_path('../../config/environment', __FILE__)
+ENV["RAILS_ENV"] ||= "test"
+require File.expand_path("../../config/environment", __FILE__)
 # Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?
-require 'spec_helper'
-require 'rspec/rails'
+require "spec_helper"
+require "rspec/rails"
 # Add additional requires below this line. Rails is not loaded until this point!
 
-require 'webmock/rspec'
+require "webmock/rspec"
 WebMock.disable_net_connect!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in

--- a/spec/services/google_docs_to_govspeak_spec.rb
+++ b/spec/services/google_docs_to_govspeak_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe GoogleDocsToGovspeak do
   describe "#to_govspeak" do
@@ -7,7 +7,7 @@ RSpec.describe GoogleDocsToGovspeak do
 
       govspeak = GoogleDocsToGovspeak.new(report).to_govspeak
 
-      expect(govspeak).to eql(File.read('spec/services/expected-markdown-sample-assessment.md'))
+      expect(govspeak).to eql(File.read("spec/services/expected-markdown-sample-assessment.md"))
     end
   end
 end


### PR DESCRIPTION
- See commits for more details.
- I'm doing this as part of the GOV.UK Developer Tooling group: https://trello.com/c/pR7GEFfU/128-make-all-current-govuk-repos-use-rubocop-govuk-instead-of-govuk-lint.