### PR TITLE
Correct table error on Govspeak guide

### DIFF
--- a/app/assets/markdown/guide.md
+++ b/app/assets/markdown/guide.md
@@ -73,7 +73,7 @@ Steps need an extra line break after the final step (in other words, 2 full blan
 
 ##Tables
 
-Create tables by separating columns with a pipe character (`|`). Add a row of hyphens for each column separated by the '|' character below this. Then use the `|` character to separate items in each row. 
+Create tables by separating columns with a pipe character (`|`). Add a row of hyphens for each column separated by the `|` character below this. Then use the `|` character to separate items in each row. 
 
     Test type | Weekday | Evening, weekend and bank holiday
     -|-


### PR DESCRIPTION
Fix the intro to the tables section – it's displaying the guidance on how to make tables as a table, and it should just be normal paragraph text.