### PR TITLE
Include functionality to transform pasted HTML into Govspeak

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Govspeak Preview
+# Govspeak preview
 
 A tiny app for previewing and converting [Govspeak](https://github.com/alphagov/govspeak).
 
-Govspeak is a markdown-derived mark-up language used by [GOV.UK](https://github.com/alphagov).
+Govspeak is a Markdown-derived mark-up language used by [GOV.UK](https://github.com/alphagov).
 
 ## Updating the guide
 

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -5,3 +5,4 @@
 
 //= require paste-html-to-markdown
 //= require html-govspeak
+//= require scroll-into-view

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -2,3 +2,6 @@
 //= require govuk_publishing_components/lib
 //= require govuk_publishing_components/components/button
 //= require govuk_publishing_components/components/govspeak
+
+//= require paste-html-to-markdown
+//= require html-govspeak

--- a/app/assets/javascripts/html-govspeak.js
+++ b/app/assets/javascripts/html-govspeak.js
@@ -1,0 +1,9 @@
+(function () {
+  var pasteGovspeakElement = document.getElementById("govspeak_input");
+  if (!pasteGovspeakElement) return;
+
+  pasteGovspeakElement.addEventListener(
+    "paste",
+    window.pasteHtmlToGovspeak.pasteListener
+  );
+})();

--- a/app/assets/javascripts/scroll-into-view.js
+++ b/app/assets/javascripts/scroll-into-view.js
@@ -1,0 +1,19 @@
+(function () {
+  document.addEventListener("DOMContentLoaded", function () {
+    var input = document.querySelector(".govspeak-preview-input form"),
+      output = document.querySelector(".govspeak-preview-output");
+
+    if (!input || !output) return;
+    if (output.dataset.ouptputIsNil === "true") return;
+
+    input.scrollIntoView({
+      behavior: setTransitionAnimation(),
+    });
+  });
+
+  function setTransitionAnimation() {
+    return window.matchMedia("(prefers-reduced-motion: reduce)").matches
+      ? "auto"
+      : "smooth";
+  }
+})();

--- a/app/assets/markdown/guide.md
+++ b/app/assets/markdown/guide.md
@@ -2,7 +2,7 @@
 
 [Govspeak](https://github.com/alphagov/govspeak) is a simplified version of [Markdown](http://daringfireball.net/projects/markdown/syntax) used on [GOV.UK](https://www.gov.uk/). It's designed to be as easy-to-read and easy-to-write as possible, using simple punctuation instead of complicated tags and code.
 
-Govspeak was developed by the [Government Digital Service]() with some extra features that we use to format content on [GOV.UK](https://www.gov.uk/).
+Govspeak was developed by the [Government Digital Service](https://gds.blog.gov.uk) with some extra features that we use to format content on [GOV.UK](https://www.gov.uk/).
 
 This guide is for Mainstream publisher Govspeak. View the [Govspeak guide for Whitehall publisher](https://www.gov.uk/guidance/how-to-publish-on-gov-uk/markdown).
 
@@ -121,7 +121,8 @@ which looks like this:
 
 ##Callouts
 
-To draw attention to content, you can use callouts. For example, you can put some text in an 'information callout' to indicate that it's something related that's worth knowing, or doesn't fit the flow of the content.  
+To draw attention to content, you can use callouts. For example, you can put some text in an 'information callout' to indicate that it's something related that's worth knowing, or does not fit the flow of the content.
+
 Only use the more severe 'warning callout' to indicate serious consequences, such as a fine or criminal proceedings.
 
 ### Information callouts
@@ -282,7 +283,7 @@ This is what that table looks like on GOV.UK:
 | Bread | 75p |
 | Milk | 99p |
 
-##Deprecated styles
+##Markdown we no longer use
 
 ###Answer summaries
 

--- a/app/assets/markdown/guide.md
+++ b/app/assets/markdown/guide.md
@@ -1,14 +1,18 @@
-##What is govspeak?
+##What is Govspeak?
 
-Govspeak is a simplified 'markup' language based on [Markdown](http://daringfireball.net/projects/markdown/syntax). It's designed to be as easy-to-read and easy-to-write as possible, using simple punctuation instead of complicated tags and code.
+[Govspeak](https://github.com/alphagov/govspeak) is a simplified version of [Markdown](http://daringfireball.net/projects/markdown/syntax) used on [GOV.UK](https://www.gov.uk/). It's designed to be as easy-to-read and easy-to-write as possible, using simple punctuation instead of complicated tags and code.
 
-Govspeak was developed by the [Government Digital Service](digital.cabinetoffice.gov.uk) with some extra features that we use to format content on [GOV.UK.](https://www.gov.uk)
+Govspeak was developed by the [Government Digital Service]() with some extra features that we use to format content on [GOV.UK](https://www.gov.uk/).
+
+This guide is for Mainstream publisher Govspeak. View the [Govspeak guide for Whitehall publisher](https://www.gov.uk/guidance/how-to-publish-on-gov-uk/markdown).
+
+Reason: Consistent capitalisation of Govspeak. Also, it makes sense to link to the github repository from the guide page rather than the 'preview' page. As we are sharing this with Whitehall publishers as a stopgap - maybe better to just direct them to the Whitehall markdown guidance so we don’t have to duplicate content?
 
 ##Acronyms
 
 List these in the following format at the end of the document and all occurrences will be marked up as acronyms:
 
-    *[FCO]: Foreign and Commonwealth Office
+    *[FCDO]: Foreign, Commonwealth and Development Office
 
 This means the full text will appear when users hover over the acronym wherever it occurs on the page.
 
@@ -46,7 +50,6 @@ Do not use bold for the address title. This is not accessible because it looks l
 This is what it looks like:
 
 **Double asterisks around text** will turn it bold. Use it sparingly.
-
 
 ##Bulleted lists
 
@@ -145,15 +148,15 @@ This looks like:
 
 ### Example callout
 
+Do not bold 'Example'. Use the appropriate heading Markdown above the example markdown if you need to draw attention to the information
+
     $E
-    **Example** 
     Open the pod bay doors.
     $E
 
 This looks like:
 
 $E
-**Example** 
 Open the pod bay doors.
 $E
 
@@ -200,8 +203,6 @@ $D
 When linking to PDFs, don't put the trailing slash '/' at the end, as the link won't work.
 
 This is only used for external download files. If the file is hosted on Whitehall, it should link to the splash page as an internal link.
-
-
 
 ##Headings
 
@@ -257,42 +258,43 @@ This looks like:
 
 ##Tables
 
-Create tables by separating columns with a pipe character (`|`). Add a row of hyphens for each column separated by the `|` character below this. Then use the `|` character to separate items in each row. 
+Create tables by separating columns with a pipe character (`|`).
+
+Add a row of hyphens for each column separated by the `|` character below this.
+
+Then use the `|` character to separate items in each row. 
+
+Use a hash (`#`) character after the pipe if the cell is the row title or the table has more than 2 columns
 
     Test type | Weekday | Evening, weekend and bank holiday
     -|-
-    Theory test | 31 | 31
-    Abridged theory | 24 | 24
-    Practical test | 62 | 75
+    # Theory test | 31 | 31
+    # Abridged theory | 24 | 24
+    # Practical test | 62 | 75
 
 This is what that table looks like on GOV.UK:
 
 Test type | Weekday | Evening, weekend and bank holiday
 -|-
-Theory test | 31 | 31
-Abridged theory | 24 | 24
-Practical test | 62 | 75 
+# Theory test | 31 | 31
+# Abridged theory | 24 | 24
+# Practical test | 62 | 75
 
-Use a hash (`#`) character after the pipe if the cell is the row title.
+Tables with 2 columns do not usually need headings in the first column.
 
+This is because there is less to scroll so the content will be clear enough without headings to explain the content.
 
-    |                                 | Monthly direct debit   | One-off payment  | 
-    | --------------------------------| -----------------------|------------------|
-    |# Two-wheeled vehicle            | £72                    | £60              |
-    |# Three-wheeled vehicle          | £132                   | £120 		      |
+    | Item | Cost |
+    |-----|-----|
+    | Bread | 75p |
+    | Milk | 99p |
 
+This is what that table looks like on GOV.UK:
 
-This is what that looks like on GOV.UK:
-
-|| Monthly direct debit| One-off payment| 
-|--|--|--|
-|# Two-wheeled vehicle | £72 | £60 |
-|# Three-wheeled vehicle | £132 | £120 |
-
-
-##Try it yourself
-
-Use the [Govspeak preview](/) to try using govspeak.
+| Item | Cost |
+|-----|-----|
+| Bread | 75p |
+| Milk | 99p |
 
 ##Deprecated styles
 

--- a/app/assets/markdown/guide.md
+++ b/app/assets/markdown/guide.md
@@ -6,8 +6,6 @@ Govspeak was developed by the [Government Digital Service]() with some extra fea
 
 This guide is for Mainstream publisher Govspeak. View the [Govspeak guide for Whitehall publisher](https://www.gov.uk/guidance/how-to-publish-on-gov-uk/markdown).
 
-Reason: Consistent capitalisation of Govspeak. Also, it makes sense to link to the github repository from the guide page rather than the 'preview' page. As we are sharing this with Whitehall publishers as a stopgap - maybe better to just direct them to the Whitehall markdown guidance so we don’t have to duplicate content?
-
 ##Acronyms
 
 List these in the following format at the end of the document and all occurrences will be marked up as acronyms:
@@ -16,13 +14,9 @@ List these in the following format at the end of the document and all occurrence
 
 This means the full text will appear when users hover over the acronym wherever it occurs on the page.
 
-###Example of acronym use
+If you use the acronym in singular and plural in your content, always put the plural one first in the list.
 
-Example: PCSO and PCSOs are both in a piece of content.
-
-Always put the longer one first in the list - otherwise PCSOs will pick up only the singular 'Police Community Support Officer'.
-
-    *[PCSOs]: Police Community Support Officers  
+    *[PCSOs]: Police Community Support Officers
     *[PCSO]: Police Community Support Officer
     
 ##Addresses
@@ -88,7 +82,7 @@ s1. Add numbers.
 s2. Check numbers.
 s3. Love numbers.
 
-Steps need an extra line break after the final step (in other words, 2 full blank lines). If you don't do this, other markdown directly after them won't work. If you have a subheading after numbered steps, add a line break after this.
+Steps need an extra line break after the final step (in other words, 2 full blank lines). If you don't do this, other Markdown directly after them won't work. If you have a subheading after numbered steps, add a line break after this.
 
 ##Buttons
 
@@ -148,7 +142,7 @@ This looks like:
 
 ### Example callout
 
-Do not bold 'Example'. Use the appropriate heading Markdown above the example markdown if you need to draw attention to the information
+Use the appropriate heading Markdown above the example Markdown if you need to draw attention to the information.
 
     $E
     Open the pod bay doors.
@@ -258,13 +252,7 @@ This looks like:
 
 ##Tables
 
-Create tables by separating columns with a pipe character (`|`).
-
-Add a row of hyphens for each column separated by the `|` character below this.
-
-Then use the `|` character to separate items in each row. 
-
-Use a hash (`#`) character after the pipe if the cell is the row title or the table has more than 2 columns
+Write your title row using the pipe character (`|`) to separate the columns. Below this, add a row of hyphens for each column separated by the `|` character. Use the `|` character to separate items in each row. Use a hash (`#`) character before the row title if the table has more than 2 columns.
 
     Test type | Weekday | Evening, weekend and bank holiday
     -|-
@@ -280,9 +268,7 @@ Test type | Weekday | Evening, weekend and bank holiday
 # Abridged theory | 24 | 24
 # Practical test | 62 | 75
 
-Tables with 2 columns do not usually need headings in the first column.
-
-This is because there is less to scroll so the content will be clear enough without headings to explain the content.
+Tables with 2 columns do not usually need headings in the first column. This is because there is less to scroll so the content will be clear enough without headings to explain the content.
 
     | Item | Cost |
     |-----|-----|
@@ -300,11 +286,8 @@ This is what that table looks like on GOV.UK:
 
 ###Answer summaries
 
-We no longer add this markdown to any new content. (You may still come across it in the 'quick answer' format.)
+We no longer add this Markdown to any new content. (You may still come across it in the 'quick answer' format.)
 
     $! This is an answer summary. $!
 
-If you see this markdown, you can delete it.
-
-*[PCSOs]: Police Community Support Officers  
-*[PCSO]: Police Community Support Officer
+If you see this Markdown, you can delete it.

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,10 +1,11 @@
-@import 'govuk_publishing_components/govuk_frontend_support';
-@import 'govuk_publishing_components/component_support';
-@import 'govuk_publishing_components/components/button';
-@import 'govuk_publishing_components/components/file-upload';
-@import 'govuk_publishing_components/components/layout-header';
-@import 'govuk_publishing_components/components/govspeak';
-@import 'govuk_publishing_components/components/textarea';
+@import "govuk_publishing_components/govuk_frontend_support";
+@import "govuk_publishing_components/component_support";
+@import "govuk_publishing_components/components/button";
+@import "govuk_publishing_components/components/file-upload";
+@import "govuk_publishing_components/components/heading";
+@import "govuk_publishing_components/components/layout-header";
+@import "govuk_publishing_components/components/govspeak";
+@import "govuk_publishing_components/components/textarea";
 
 body {
   margin: 0;
@@ -12,7 +13,7 @@ body {
 
 .govspeak-preview-input {
   @include govuk-font(19);
-  background: govuk-colour('light-grey');
+  background: govuk-colour("light-grey");
   padding: 2em;
   margin-top: govuk-spacing(4);
 
@@ -26,7 +27,6 @@ body {
     margin-bottom: govuk-spacing(3);
   }
 }
-
 
 .govspeak-preview-output {
   border-top: 1px solid $govuk-border-colour;
@@ -56,12 +56,11 @@ body {
     margin: 0;
 
     &::before {
-      content: 'govspeak';
+      content: "govspeak";
       position: absolute;
       left: 0;
       top: 0;
-      padding-left: .5em;
-      padding-right: .5em;
+      padding-left: 15px;
       background: govuk-colour("light-grey");
     }
   }
@@ -75,5 +74,17 @@ body {
 .validation-warning {
   background: $govuk-error-colour;
   color: govuk-colour("white");
-  padding: .5em 1em;
+  padding: 0.5em 1em;
+}
+
+pre {
+  min-height: 100px;
+  max-height: 500px;
+  overflow-y: scroll;
+  border: 1px solid black;
+  white-space: pre-wrap;
+}
+
+#paste-formatted-html-input {
+  white-space: pre;
 }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -3,6 +3,7 @@
 @import "govuk_publishing_components/components/button";
 @import "govuk_publishing_components/components/file-upload";
 @import "govuk_publishing_components/components/heading";
+@import "govuk_publishing_components/components/inset-text";
 @import "govuk_publishing_components/components/layout-header";
 @import "govuk_publishing_components/components/govspeak";
 @import "govuk_publishing_components/components/textarea";

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -56,11 +56,10 @@ body {
     margin: 0;
 
     &::before {
-      content: "govspeak";
-      position: absolute;
-      left: 0;
-      top: 0;
-      padding-left: 15px;
+      content: "Govspeak";
+      display: block;
+      font-family: monospace;
+      padding: 0 0 15px;
       background: govuk-colour("light-grey");
     }
   }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -45,7 +45,7 @@ body {
   .code-snippet + p,
   pre {
     @include govuk-font(16);
-    overflow-x: auto;
+    overflow: auto;
     max-width: 100%;
     position: relative;
     display: inline-block;
@@ -55,11 +55,13 @@ body {
     padding-top: 2.2em;
     margin: 0;
 
-    &::before {
-      content: "Govspeak";
-      display: block;
-      font-family: monospace;
-      padding: 0 0 15px;
+  &::before {
+      content: 'govspeak';
+      position: absolute;
+      left: 0;
+      top: 0;
+      padding-left: .5em;
+      padding-right: .5em;
       background: govuk-colour("light-grey");
     }
   }

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -2,8 +2,8 @@ module ApplicationHelper
   def navigation_items
     items = []
 
-    items << { text: "Govspeak Preview", href: "/", active: is_current?("/") }
-    items << { text: "Govspeak Guide", href: "/guide", active: is_current?("/guide") }
+    items << { text: "Govspeak preview", href: "/", active: is_current?("/") }
+    items << { text: "Govspeak guide", href: "/guide", active: is_current?("/guide") }
     items << { text: "Convert Google Doc to Govspeak", href: "/convert", active: is_current?("/convert") }
 
     items

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -2,9 +2,9 @@ module ApplicationHelper
   def navigation_items
     items = []
 
-    items << { text: "Govspeak preview", href: "/", active: is_current?("/") }
+    items << { text: "Govspeak converter", href: "/", active: is_current?("/") }
     items << { text: "Govspeak guide", href: "/guide", active: is_current?("/guide") }
-    items << { text: "Convert Google Doc to Govspeak", href: "/convert", active: is_current?("/convert") }
+    items << { text: "Convert Google Docs to Govspeak", href: "/convert", active: is_current?("/convert") }
 
     items
   end

--- a/app/views/convert/index.html.erb
+++ b/app/views/convert/index.html.erb
@@ -1,6 +1,6 @@
 <div class="govspeak-preview-input">
   <%= render "govuk_publishing_components/components/heading", {
-    text: "Convert Google doc to Govspeak",
+    text: "Convert Google Doc to Govspeak",
     font_size: "l",
     heading_level: 1,
     margin_bottom: 4
@@ -11,7 +11,7 @@
   </p>
 
   <p>
-    You'll have to <a href="https://www.gov.uk/guidance/how-to-publish-on-gov-uk/markdown" rel="nofollow" class="govuk-link">convert tables and write additional Govspeak markdown</a> separately.
+    You'll have to <a href="https://www.gov.uk/guidance/how-to-publish-on-gov-uk/markdown" rel="nofollow" class="govuk-link">convert tables and write additional Govspeak Markdown</a> separately.
   </p>
 
   <p class="govuk-body">

--- a/app/views/convert/index.html.erb
+++ b/app/views/convert/index.html.erb
@@ -1,3 +1,5 @@
+<% content_for :title, "Convert Google Docs to Govspeak and preview" %>
+
 <div class="govspeak-preview-input">
   <%= render "govuk_publishing_components/components/heading", {
     text: "Convert Google Docs to Govspeak and preview",

--- a/app/views/convert/index.html.erb
+++ b/app/views/convert/index.html.erb
@@ -1,9 +1,20 @@
 <div class="govspeak-preview-input">
-  <p>
-    Converts Google Docs into <a href="https://github.com/alphagov/govspeak" class="govuk-link">Govspeak</a> ready for Specialist Publisher.<br/>
+  <%= render "govuk_publishing_components/components/heading", {
+    text: "Convert Google doc to Govspeak",
+    font_size: "l",
+    heading_level: 1,
+    margin_bottom: 4
+  } %>
+
+  <p class="govuk-body">
+    Converts Google Docs into basic <a href="https://github.com/alphagov/govspeak" rel="nofollow" class="govuk-link">Govspeak</a>.
   </p>
 
   <p>
+    You'll have to <a href="https://www.gov.uk/guidance/how-to-publish-on-gov-uk/markdown" rel="nofollow" class="govuk-link">convert tables and write additional Govspeak markdown</a> separately.
+  </p>
+
+  <p class="govuk-body">
     To download the file, go to Google Docs and click <%= link_to "File > Download as > Web page (.html, zipped)", image_url("govspeak-preview.gif"), class: "govuk-link" %>
   </p>
 

--- a/app/views/convert/index.html.erb
+++ b/app/views/convert/index.html.erb
@@ -1,34 +1,47 @@
 <div class="govspeak-preview-input">
   <%= render "govuk_publishing_components/components/heading", {
-    text: "Convert Google Doc to Govspeak",
+    text: "Convert Google Docs to Govspeak and preview",
     font_size: "l",
     heading_level: 1,
     margin_bottom: 4
   } %>
 
-  <p class="govuk-body">
-    Converts Google Docs into basic <a href="https://github.com/alphagov/govspeak" rel="nofollow" class="govuk-link">Govspeak</a>.
-  </p>
-
-  <p>
-    You'll have to <a href="https://www.gov.uk/guidance/how-to-publish-on-gov-uk/markdown" rel="nofollow" class="govuk-link">convert tables and write additional Govspeak Markdown</a> separately.
-  </p>
+  <% if !@govspeak_output.blank? %>
+    <%= render "govuk_publishing_components/components/inset_text", {
+      text: "Conversion and preview updated"
+    } %>
+  <% end %>
 
   <p class="govuk-body">
-    To download the file, go to Google Docs and click <%= link_to "File > Download as > Web page (.html, zipped)", image_url("govspeak-preview.gif"), class: "govuk-link" %>
+    This converts Google Docs into basic Govspeak Markdown and previews what it will look like on GOV.UK. You'll have to <a href="/guide" class="govuk-link">write additional Govspeak</a> separately.
   </p>
+
+  <p class="govuk-body">To convert a Google Doc into Govspeak:</p>
+
+  <%= render "govuk_publishing_components/components/list", {
+    list_type: "number",
+    visible_counters: true,
+    items: [
+      "Remove images from the Google Doc.",
+      "Select 'File' in the Google Doc.",
+      "Download the file as 'Web page (.html, zipped)'.",
+      "On this page, select 'Choose file' to upload the zipped file.",
+      "Select 'Convert'."
+    ]
+  } %>
 
   <%= form_tag({ action: :create }, multipart: true) do %>
-    <label for="govspeak_input"></label>
     <%= render "govuk_publishing_components/components/file_upload", {
-      label: {
-        text: "Upload a file"
-      },
       name: "upload[file]"
     } %>
+
     <%= render "govuk_publishing_components/components/button", {
       text: "Convert",
     } %>
+
+    <% if !@govspeak_output.blank? %>
+      <p class="govuk-!-margin-bottom-0">Conversion and preview updated below</p>
+    <% end %>
   <% end %>
 </div>
 
@@ -37,7 +50,7 @@
   <form>
     <%= render "govuk_publishing_components/components/textarea", {
       label: {
-        text: "Converted govspeak:"
+        text: "Converted into Govspeak"
       },
       id: "govspeak_input",
       name: "govspeak",
@@ -47,12 +60,19 @@
 </div>
 <% end %>
 
-<div class="govspeak-preview-output">
+<div class="govspeak-preview-output" data-ouptput-is-nil="<%= @govspeak_output.nil? %>">
   <% if (@govspeak_doc && !@govspeak_doc.valid?) %>
     <p class="validation-warning">This govspeak doesn't validate and may not be accepted by publishing tools</p>
   <% end %>
 
-  <article>
-    <%= render 'govuk_publishing_components/components/govspeak', content: raw(@govspeak_output) %>
-  </article>
+  <% if !@govspeak_doc.nil? %>
+    <%= render "govuk_publishing_components/components/heading", {
+      text: "How this will look on GOV.UK",
+      font_size: "m",
+      heading_level: 2,
+      margin_bottom: 4
+    } %>
+  <% end %>
+
+  <%= render 'govuk_publishing_components/components/govspeak', content: raw(@govspeak_output) %>
 </div>

--- a/app/views/guide/index.html.erb
+++ b/app/views/guide/index.html.erb
@@ -1,3 +1,5 @@
+<% content_for :title, "Govspeak guide" %>
+
 <div class="govspeak-preview-output govspeak-guide">
   <%= render "govuk_publishing_components/components/heading", {
     text: "Govspeak guide",

--- a/app/views/guide/index.html.erb
+++ b/app/views/guide/index.html.erb
@@ -1,4 +1,11 @@
-<div class="govspeak-preview-output govspeak-guide">
+<div class="govspeak-preview-input govspeak-guide">
+  <%= render "govuk_publishing_components/components/heading", {
+    text: "Govspeak Guide",
+    font_size: "l",
+    heading_level: 1,
+    margin_bottom: 4
+  } %>
+
   <% if (@govspeak_doc && !@govspeak_doc.valid?) %>
     <p class="validation-warning">This govspeak doesn't validate and may not be accepted by publishing tools</p>
   <% end %>

--- a/app/views/guide/index.html.erb
+++ b/app/views/guide/index.html.erb
@@ -1,6 +1,6 @@
-<div class="govspeak-preview-input govspeak-guide">
+<div class="govspeak-preview-output govspeak-guide">
   <%= render "govuk_publishing_components/components/heading", {
-    text: "Govspeak Guide",
+    text: "Govspeak guide",
     font_size: "l",
     heading_level: 1,
     margin_bottom: 4

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title>Govspeak Preview</title>
+  <title>Govspeak preview</title>
   <%= stylesheet_link_tag "application", :media => "all" %>
   <%= csrf_meta_tags %>
 </head>
@@ -9,7 +9,7 @@
   <div id="wrapper">
     <%= render "govuk_publishing_components/components/layout_header", {
       environment: "example",
-      product_name: "Govspeak Preview",
+      product_name: "Govspeak preview",
       navigation_items: navigation_items
     } %>
     <main class="govuk-width-container">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title>Govspeak preview</title>
+  <title><%= yield(:title) %></title>
   <%= stylesheet_link_tag "application", :media => "all" %>
   <%= csrf_meta_tags %>
 </head>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,8 +8,8 @@
 <body>
   <div id="wrapper">
     <%= render "govuk_publishing_components/components/layout_header", {
-      environment: "example",
-      product_name: "Govspeak preview",
+      environment: "beta",
+      product_name: "Govspeak converter",
       navigation_items: navigation_items
     } %>
     <main class="govuk-width-container">

--- a/app/views/preview/new.html.erb
+++ b/app/views/preview/new.html.erb
@@ -1,6 +1,6 @@
 <div class="govspeak-preview-input">
   <%= render "govuk_publishing_components/components/heading", {
-    text: "Govspeak Preview",
+    text: "Govspeak preview",
     font_size: "l",
     heading_level: 1,
     margin_bottom: 4
@@ -10,9 +10,8 @@
     <a href="https://govspeak-preview.herokuapp.com/guide" rel="nofollow" class="govuk-link">Govspeak is a simplified version of Markdown used on GOV.UK</a>.
   </p>
 
-  <p class="govuk-body">Enter Govspeak or text from an original digital document (not PDF) to preview how your content will appear on GOV.UK.</p>
-  <p class="govuk-body">You can also paste formatted text from an email, website or any word document (but not a pdf) to convert it into Govspeak:</p>
-
+  <p class="govuk-body">Enter Govspeak to preview how your content will appear on GOV.UK.</p>
+  <p class="govuk-body">You can also paste formatted text from an original digital document like an email, website or word document (but not a PDF) to convert it into Govspeak:</p>
   <ul class="govuk-list govuk-list--bullet">
     <li>headings</li>
     <li>bullets</li>
@@ -28,7 +27,7 @@
   <form method="post" action="/preview/">
     <%= render "govuk_publishing_components/components/textarea", {
       label: {
-        text: "Paste rich text content into the form below:"
+        text: "Enter Govspeak or paste text to preview:"
       },
       id: "govspeak_input",
       name: "govspeak",

--- a/app/views/preview/new.html.erb
+++ b/app/views/preview/new.html.erb
@@ -1,17 +1,20 @@
 <div class="govspeak-preview-input">
   <%= render "govuk_publishing_components/components/heading", {
-    text: "Govspeak preview",
+    text: "Govspeak converter and preview",
     font_size: "l",
     heading_level: 1,
     margin_bottom: 4
   } %>
 
-  <p class="govuk-body">
-    <a href="https://govspeak-preview.herokuapp.com/guide" rel="nofollow" class="govuk-link">Govspeak is a simplified version of Markdown used on GOV.UK</a>.
-  </p>
+  <% if !@govspeak_output.blank? %>
+    <%= render "govuk_publishing_components/components/inset_text", {
+      text: "Preview updated"
+    } %>
+  <% end %>
 
-  <p class="govuk-body">Enter Govspeak to preview how your content will appear on GOV.UK.</p>
-  <p class="govuk-body">You can also paste formatted text from an original digital document like an email, website or word document (but not a PDF) to convert it into Govspeak:</p>
+  <p class="govuk-body">Govspeak is a simplified version of Markdown used on GOV.UK.</p>
+  <p class="govuk-body">Paste formatted text from an original digital document like an email, website or word document here to convert it into basic Govspeak. This will convert:</p>
+
   <ul class="govuk-list govuk-list--bullet">
     <li>headings</li>
     <li>bullets</li>
@@ -20,31 +23,41 @@
     <li>email addresses</li>
   </ul>
 
-  <p class="govuk-body">
-    For tables, use the <a href="https://www.tablesgenerator.com/markdown_tables#" rel="nofollow" class="govuk-link">tables generator</a>.
-  </p>
+  <p class="govuk-body">You'll have to <a href="/guide" class="govuk-link">write additional Govspeak</a> separately. You cannot paste from a PDF</a>.</p>
 
   <form method="post" action="/preview/">
     <%= render "govuk_publishing_components/components/textarea", {
       label: {
-        text: "Enter Govspeak or paste text to preview:"
+        text: "Paste formatted text or Govspeak to preview what it will look like on GOV.UK:"
       },
       id: "govspeak_input",
       name: "govspeak",
       value: @govspeak_input
     } %>
+
     <%= render "govuk_publishing_components/components/button", {
       text: "Preview",
     } %>
+
+    <% if !@govspeak_output.blank? %>
+      <p class="govuk-!-margin-bottom-0">Preview updated below</p>
+    <% end %>
   </form>
 </div>
 
-<div class="govspeak-preview-output">
+<div class="govspeak-preview-output" data-ouptput-is-nil="<%= @govspeak_output.nil? %>">
   <% if (@govspeak_doc && !@govspeak_doc.valid?) %>
     <p class="validation-warning">This govspeak doesn't validate and may not be accepted by publishing tools</p>
   <% end %>
 
-  <article>
-    <%= render 'govuk_publishing_components/components/govspeak', content: raw(@govspeak_output) %>
-  </article>
+  <% if !@govspeak_output.blank? %>
+    <%= render "govuk_publishing_components/components/heading", {
+      text: "How this will look on GOV.UK",
+      font_size: "m",
+      heading_level: 2,
+      margin_bottom: 4
+    } %>
+  <% end %>
+
+  <%= render 'govuk_publishing_components/components/govspeak', content: raw(@govspeak_output) %>
 </div>

--- a/app/views/preview/new.html.erb
+++ b/app/views/preview/new.html.erb
@@ -1,3 +1,5 @@
+<% content_for :title, "Govspeak converter and preview" %>
+
 <div class="govspeak-preview-input">
   <%= render "govuk_publishing_components/components/heading", {
     text: "Govspeak converter and preview",

--- a/app/views/preview/new.html.erb
+++ b/app/views/preview/new.html.erb
@@ -1,22 +1,34 @@
 <div class="govspeak-preview-input">
-  <p>
-    <a href="https://github.com/alphagov/govspeak" class="govuk-link">Govspeak</a> is a simplified 'markup' language based on
-    <a href="http://daringfireball.net/projects/markdown/syntax" class="govuk-link">Markdown</a>.
-    It's designed to be as easy-to-read and easy-to-write as possible, using
-    simple punctuation instead of complicated tags and code.
+  <%= render "govuk_publishing_components/components/heading", {
+    text: "Govspeak Preview",
+    font_size: "l",
+    heading_level: 1,
+    margin_bottom: 4
+  } %>
+
+  <p class="govuk-body">
+    <a href="https://govspeak-preview.herokuapp.com/guide" rel="nofollow" class="govuk-link">Govspeak is a simplified version of Markdown used on GOV.UK</a>.
   </p>
 
-  <p>
-    Check out the <a href="/guide" class="govuk-link">usage docs</a>
-    &ndash; or <a href="/?styleguide=markdown" class="govuk-link">try</a>,
-    <a href="/?styleguide=govspeak" class="govuk-link">some</a>,
-    <a href="/?styleguide=sa_outcome" class="govuk-link">examples</a>.
+  <p class="govuk-body">Enter Govspeak or text from an original digital document (not PDF) to preview how your content will appear on GOV.UK.</p>
+  <p class="govuk-body">You can also paste formatted text from an email, website or any word document (but not a pdf) to convert it into Govspeak:</p>
+
+  <ul class="govuk-list govuk-list--bullet">
+    <li>headings</li>
+    <li>bullets</li>
+    <li>numbered lists</li>
+    <li>links</li>
+    <li>email addresses</li>
+  </ul>
+
+  <p class="govuk-body">
+    For tables, use the <a href="https://www.tablesgenerator.com/markdown_tables#" rel="nofollow" class="govuk-link">tables generator</a>.
   </p>
 
   <form method="post" action="/preview/">
     <%= render "govuk_publishing_components/components/textarea", {
       label: {
-        text: "Enter govspeak to preview:"
+        text: "Paste rich text content into the form below:"
       },
       id: "govspeak_input",
       name: "govspeak",

--- a/lib/assets/javascripts/paste-html-to-markdown.js
+++ b/lib/assets/javascripts/paste-html-to-markdown.js
@@ -1,0 +1,1450 @@
+(function (global, factory) {
+  typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
+  typeof define === 'function' && define.amd ? define(['exports'], factory) :
+  (global = typeof globalThis !== 'undefined' ? globalThis : global || self, factory(global.pasteHtmlToGovspeak = {}));
+}(this, (function (exports) { 'use strict';
+
+  function extend (destination) {
+    for (var i = 1; i < arguments.length; i++) {
+      var source = arguments[i];
+      for (var key in source) {
+        if (source.hasOwnProperty(key)) destination[key] = source[key];
+      }
+    }
+    return destination
+  }
+
+  function repeat (character, count) {
+    return Array(count + 1).join(character)
+  }
+
+  var blockElements = [
+    'address', 'article', 'aside', 'audio', 'blockquote', 'body', 'canvas',
+    'center', 'dd', 'dir', 'div', 'dl', 'dt', 'fieldset', 'figcaption',
+    'figure', 'footer', 'form', 'frameset', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
+    'header', 'hgroup', 'hr', 'html', 'isindex', 'li', 'main', 'menu', 'nav',
+    'noframes', 'noscript', 'ol', 'output', 'p', 'pre', 'section', 'table',
+    'tbody', 'td', 'tfoot', 'th', 'thead', 'tr', 'ul'
+  ];
+
+  function isBlock (node) {
+    return blockElements.indexOf(node.nodeName.toLowerCase()) !== -1
+  }
+
+  var voidElements = [
+    'area', 'base', 'br', 'col', 'command', 'embed', 'hr', 'img', 'input',
+    'keygen', 'link', 'meta', 'param', 'source', 'track', 'wbr'
+  ];
+
+  function isVoid (node) {
+    return voidElements.indexOf(node.nodeName.toLowerCase()) !== -1
+  }
+
+  var voidSelector = voidElements.join();
+  function hasVoid (node) {
+    return node.querySelector && node.querySelector(voidSelector)
+  }
+
+  var rules = {};
+
+  rules.paragraph = {
+    filter: 'p',
+
+    replacement: function (content) {
+      return '\n\n' + content + '\n\n'
+    }
+  };
+
+  rules.lineBreak = {
+    filter: 'br',
+
+    replacement: function (content, node, options) {
+      return options.br + '\n'
+    }
+  };
+
+  rules.heading = {
+    filter: ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'],
+
+    replacement: function (content, node, options) {
+      var hLevel = Number(node.nodeName.charAt(1));
+
+      if (options.headingStyle === 'setext' && hLevel < 3) {
+        var underline = repeat((hLevel === 1 ? '=' : '-'), content.length);
+        return (
+          '\n\n' + content + '\n' + underline + '\n\n'
+        )
+      } else {
+        return '\n\n' + repeat('#', hLevel) + ' ' + content + '\n\n'
+      }
+    }
+  };
+
+  rules.blockquote = {
+    filter: 'blockquote',
+
+    replacement: function (content) {
+      content = content.replace(/^\n+|\n+$/g, '');
+      content = content.replace(/^/gm, '> ');
+      return '\n\n' + content + '\n\n'
+    }
+  };
+
+  rules.list = {
+    filter: ['ul', 'ol'],
+
+    replacement: function (content, node) {
+      var parent = node.parentNode;
+      if (parent.nodeName === 'LI' && parent.lastElementChild === node) {
+        return '\n' + content
+      } else {
+        return '\n\n' + content + '\n\n'
+      }
+    }
+  };
+
+  rules.listItem = {
+    filter: 'li',
+
+    replacement: function (content, node, options) {
+      content = content
+        .replace(/^\n+/, '') // remove leading newlines
+        .replace(/\n+$/, '\n') // replace trailing newlines with just a single one
+        .replace(/\n/gm, '\n    '); // indent
+      var prefix = options.bulletListMarker + '   ';
+      var parent = node.parentNode;
+      if (parent.nodeName === 'OL') {
+        var start = parent.getAttribute('start');
+        var index = Array.prototype.indexOf.call(parent.children, node);
+        prefix = (start ? Number(start) + index : index + 1) + '.  ';
+      }
+      return (
+        prefix + content + (node.nextSibling && !/\n$/.test(content) ? '\n' : '')
+      )
+    }
+  };
+
+  rules.indentedCodeBlock = {
+    filter: function (node, options) {
+      return (
+        options.codeBlockStyle === 'indented' &&
+        node.nodeName === 'PRE' &&
+        node.firstChild &&
+        node.firstChild.nodeName === 'CODE'
+      )
+    },
+
+    replacement: function (content, node, options) {
+      return (
+        '\n\n    ' +
+        node.firstChild.textContent.replace(/\n/g, '\n    ') +
+        '\n\n'
+      )
+    }
+  };
+
+  rules.fencedCodeBlock = {
+    filter: function (node, options) {
+      return (
+        options.codeBlockStyle === 'fenced' &&
+        node.nodeName === 'PRE' &&
+        node.firstChild &&
+        node.firstChild.nodeName === 'CODE'
+      )
+    },
+
+    replacement: function (content, node, options) {
+      var className = node.firstChild.className || '';
+      var language = (className.match(/language-(\S+)/) || [null, ''])[1];
+      var code = node.firstChild.textContent;
+
+      var fenceChar = options.fence.charAt(0);
+      var fenceSize = 3;
+      var fenceInCodeRegex = new RegExp('^' + fenceChar + '{3,}', 'gm');
+
+      var match;
+      while ((match = fenceInCodeRegex.exec(code))) {
+        if (match[0].length >= fenceSize) {
+          fenceSize = match[0].length + 1;
+        }
+      }
+
+      var fence = repeat(fenceChar, fenceSize);
+
+      return (
+        '\n\n' + fence + language + '\n' +
+        code.replace(/\n$/, '') +
+        '\n' + fence + '\n\n'
+      )
+    }
+  };
+
+  rules.horizontalRule = {
+    filter: 'hr',
+
+    replacement: function (content, node, options) {
+      return '\n\n' + options.hr + '\n\n'
+    }
+  };
+
+  rules.inlineLink = {
+    filter: function (node, options) {
+      return (
+        options.linkStyle === 'inlined' &&
+        node.nodeName === 'A' &&
+        node.getAttribute('href')
+      )
+    },
+
+    replacement: function (content, node) {
+      var href = node.getAttribute('href');
+      var title = node.title ? ' "' + node.title + '"' : '';
+      return '[' + content + '](' + href + title + ')'
+    }
+  };
+
+  rules.referenceLink = {
+    filter: function (node, options) {
+      return (
+        options.linkStyle === 'referenced' &&
+        node.nodeName === 'A' &&
+        node.getAttribute('href')
+      )
+    },
+
+    replacement: function (content, node, options) {
+      var href = node.getAttribute('href');
+      var title = node.title ? ' "' + node.title + '"' : '';
+      var replacement;
+      var reference;
+
+      switch (options.linkReferenceStyle) {
+        case 'collapsed':
+          replacement = '[' + content + '][]';
+          reference = '[' + content + ']: ' + href + title;
+          break
+        case 'shortcut':
+          replacement = '[' + content + ']';
+          reference = '[' + content + ']: ' + href + title;
+          break
+        default:
+          var id = this.references.length + 1;
+          replacement = '[' + content + '][' + id + ']';
+          reference = '[' + id + ']: ' + href + title;
+      }
+
+      this.references.push(reference);
+      return replacement
+    },
+
+    references: [],
+
+    append: function (options) {
+      var references = '';
+      if (this.references.length) {
+        references = '\n\n' + this.references.join('\n') + '\n\n';
+        this.references = []; // Reset references
+      }
+      return references
+    }
+  };
+
+  rules.emphasis = {
+    filter: ['em', 'i'],
+
+    replacement: function (content, node, options) {
+      if (!content.trim()) return ''
+      return options.emDelimiter + content + options.emDelimiter
+    }
+  };
+
+  rules.strong = {
+    filter: ['strong', 'b'],
+
+    replacement: function (content, node, options) {
+      if (!content.trim()) return ''
+      return options.strongDelimiter + content + options.strongDelimiter
+    }
+  };
+
+  rules.code = {
+    filter: function (node) {
+      var hasSiblings = node.previousSibling || node.nextSibling;
+      var isCodeBlock = node.parentNode.nodeName === 'PRE' && !hasSiblings;
+
+      return node.nodeName === 'CODE' && !isCodeBlock
+    },
+
+    replacement: function (content) {
+      if (!content.trim()) return ''
+
+      var delimiter = '`';
+      var leadingSpace = '';
+      var trailingSpace = '';
+      var matches = content.match(/`+/gm);
+      if (matches) {
+        if (/^`/.test(content)) leadingSpace = ' ';
+        if (/`$/.test(content)) trailingSpace = ' ';
+        while (matches.indexOf(delimiter) !== -1) delimiter = delimiter + '`';
+      }
+
+      return delimiter + leadingSpace + content + trailingSpace + delimiter
+    }
+  };
+
+  rules.image = {
+    filter: 'img',
+
+    replacement: function (content, node) {
+      var alt = node.alt || '';
+      var src = node.getAttribute('src') || '';
+      var title = node.title || '';
+      var titlePart = title ? ' "' + title + '"' : '';
+      return src ? '![' + alt + ']' + '(' + src + titlePart + ')' : ''
+    }
+  };
+
+  /**
+   * Manages a collection of rules used to convert HTML to Markdown
+   */
+
+  function Rules (options) {
+    this.options = options;
+    this._keep = [];
+    this._remove = [];
+
+    this.blankRule = {
+      replacement: options.blankReplacement
+    };
+
+    this.keepReplacement = options.keepReplacement;
+
+    this.defaultRule = {
+      replacement: options.defaultReplacement
+    };
+
+    this.array = [];
+    for (var key in options.rules) this.array.push(options.rules[key]);
+  }
+
+  Rules.prototype = {
+    add: function (key, rule) {
+      this.array.unshift(rule);
+    },
+
+    keep: function (filter) {
+      this._keep.unshift({
+        filter: filter,
+        replacement: this.keepReplacement
+      });
+    },
+
+    remove: function (filter) {
+      this._remove.unshift({
+        filter: filter,
+        replacement: function () {
+          return ''
+        }
+      });
+    },
+
+    forNode: function (node) {
+      if (node.isBlank) return this.blankRule
+      var rule;
+
+      if ((rule = findRule(this.array, node, this.options))) return rule
+      if ((rule = findRule(this._keep, node, this.options))) return rule
+      if ((rule = findRule(this._remove, node, this.options))) return rule
+
+      return this.defaultRule
+    },
+
+    forEach: function (fn) {
+      for (var i = 0; i < this.array.length; i++) fn(this.array[i], i);
+    }
+  };
+
+  function findRule (rules, node, options) {
+    for (var i = 0; i < rules.length; i++) {
+      var rule = rules[i];
+      if (filterValue(rule, node, options)) return rule
+    }
+    return void 0
+  }
+
+  function filterValue (rule, node, options) {
+    var filter = rule.filter;
+    if (typeof filter === 'string') {
+      if (filter === node.nodeName.toLowerCase()) return true
+    } else if (Array.isArray(filter)) {
+      if (filter.indexOf(node.nodeName.toLowerCase()) > -1) return true
+    } else if (typeof filter === 'function') {
+      if (filter.call(rule, node, options)) return true
+    } else {
+      throw new TypeError('`filter` needs to be a string, array, or function')
+    }
+  }
+
+  /**
+   * The collapseWhitespace function is adapted from collapse-whitespace
+   * by Luc Thevenard.
+   *
+   * The MIT License (MIT)
+   *
+   * Copyright (c) 2014 Luc Thevenard <lucthevenard@gmail.com>
+   *
+   * Permission is hereby granted, free of charge, to any person obtaining a copy
+   * of this software and associated documentation files (the "Software"), to deal
+   * in the Software without restriction, including without limitation the rights
+   * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+   * copies of the Software, and to permit persons to whom the Software is
+   * furnished to do so, subject to the following conditions:
+   *
+   * The above copyright notice and this permission notice shall be included in
+   * all copies or substantial portions of the Software.
+   *
+   * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+   * THE SOFTWARE.
+   */
+
+  /**
+   * collapseWhitespace(options) removes extraneous whitespace from an the given element.
+   *
+   * @param {Object} options
+   */
+  function collapseWhitespace (options) {
+    var element = options.element;
+    var isBlock = options.isBlock;
+    var isVoid = options.isVoid;
+    var isPre = options.isPre || function (node) {
+      return node.nodeName === 'PRE'
+    };
+
+    if (!element.firstChild || isPre(element)) return
+
+    var prevText = null;
+    var prevVoid = false;
+
+    var prev = null;
+    var node = next(prev, element, isPre);
+
+    while (node !== element) {
+      if (node.nodeType === 3 || node.nodeType === 4) { // Node.TEXT_NODE or Node.CDATA_SECTION_NODE
+        var text = node.data.replace(/[ \r\n\t]+/g, ' ');
+
+        if ((!prevText || / $/.test(prevText.data)) &&
+            !prevVoid && text[0] === ' ') {
+          text = text.substr(1);
+        }
+
+        // `text` might be empty at this point.
+        if (!text) {
+          node = remove(node);
+          continue
+        }
+
+        node.data = text;
+
+        prevText = node;
+      } else if (node.nodeType === 1) { // Node.ELEMENT_NODE
+        if (isBlock(node) || node.nodeName === 'BR') {
+          if (prevText) {
+            prevText.data = prevText.data.replace(/ $/, '');
+          }
+
+          prevText = null;
+          prevVoid = false;
+        } else if (isVoid(node)) {
+          // Avoid trimming space around non-block, non-BR void elements.
+          prevText = null;
+          prevVoid = true;
+        }
+      } else {
+        node = remove(node);
+        continue
+      }
+
+      var nextNode = next(prev, node, isPre);
+      prev = node;
+      node = nextNode;
+    }
+
+    if (prevText) {
+      prevText.data = prevText.data.replace(/ $/, '');
+      if (!prevText.data) {
+        remove(prevText);
+      }
+    }
+  }
+
+  /**
+   * remove(node) removes the given node from the DOM and returns the
+   * next node in the sequence.
+   *
+   * @param {Node} node
+   * @return {Node} node
+   */
+  function remove (node) {
+    var next = node.nextSibling || node.parentNode;
+
+    node.parentNode.removeChild(node);
+
+    return next
+  }
+
+  /**
+   * next(prev, current, isPre) returns the next node in the sequence, given the
+   * current and previous nodes.
+   *
+   * @param {Node} prev
+   * @param {Node} current
+   * @param {Function} isPre
+   * @return {Node}
+   */
+  function next (prev, current, isPre) {
+    if ((prev && prev.parentNode === current) || isPre(current)) {
+      return current.nextSibling || current.parentNode
+    }
+
+    return current.firstChild || current.nextSibling || current.parentNode
+  }
+
+  /*
+   * Set up window for Node.js
+   */
+
+  var root = (typeof window !== 'undefined' ? window : {});
+
+  /*
+   * Parsing HTML strings
+   */
+
+  function canParseHTMLNatively () {
+    var Parser = root.DOMParser;
+    var canParse = false;
+
+    // Adapted from https://gist.github.com/1129031
+    // Firefox/Opera/IE throw errors on unsupported types
+    try {
+      // WebKit returns null on unsupported types
+      if (new Parser().parseFromString('', 'text/html')) {
+        canParse = true;
+      }
+    } catch (e) {}
+
+    return canParse
+  }
+
+  function createHTMLParser () {
+    var Parser = function () {};
+
+    {
+      var JSDOM = require('jsdom').JSDOM;
+      Parser.prototype.parseFromString = function (string) {
+        return new JSDOM(string).window.document
+      };
+    }
+    return Parser
+  }
+
+  var HTMLParser = canParseHTMLNatively() ? root.DOMParser : createHTMLParser();
+
+  function RootNode (input) {
+    var root;
+    if (typeof input === 'string') {
+      var doc = htmlParser().parseFromString(
+        // DOM parsers arrange elements in the <head> and <body>.
+        // Wrapping in a custom element ensures elements are reliably arranged in
+        // a single element.
+        '<x-turndown id="turndown-root">' + input + '</x-turndown>',
+        'text/html'
+      );
+      root = doc.getElementById('turndown-root');
+    } else {
+      root = input.cloneNode(true);
+    }
+    collapseWhitespace({
+      element: root,
+      isBlock: isBlock,
+      isVoid: isVoid
+    });
+
+    return root
+  }
+
+  var _htmlParser;
+  function htmlParser () {
+    _htmlParser = _htmlParser || new HTMLParser();
+    return _htmlParser
+  }
+
+  function Node (node) {
+    node.isBlock = isBlock(node);
+    node.isCode = node.nodeName.toLowerCase() === 'code' || node.parentNode.isCode;
+    node.isBlank = isBlank(node);
+    node.flankingWhitespace = flankingWhitespace(node);
+    return node
+  }
+
+  function isBlank (node) {
+    return (
+      ['A', 'TH', 'TD', 'IFRAME', 'SCRIPT', 'AUDIO', 'VIDEO'].indexOf(node.nodeName) === -1 &&
+      /^\s*$/i.test(node.textContent) &&
+      !isVoid(node) &&
+      !hasVoid(node)
+    )
+  }
+
+  function flankingWhitespace (node) {
+    var leading = '';
+    var trailing = '';
+
+    if (!node.isBlock) {
+      var hasLeading = /^\s/.test(node.textContent);
+      var hasTrailing = /\s$/.test(node.textContent);
+      var blankWithSpaces = node.isBlank && hasLeading && hasTrailing;
+
+      if (hasLeading && !isFlankedByWhitespace('left', node)) {
+        leading = ' ';
+      }
+
+      if (!blankWithSpaces && hasTrailing && !isFlankedByWhitespace('right', node)) {
+        trailing = ' ';
+      }
+    }
+
+    return { leading: leading, trailing: trailing }
+  }
+
+  function isFlankedByWhitespace (side, node) {
+    var sibling;
+    var regExp;
+    var isFlanked;
+
+    if (side === 'left') {
+      sibling = node.previousSibling;
+      regExp = / $/;
+    } else {
+      sibling = node.nextSibling;
+      regExp = /^ /;
+    }
+
+    if (sibling) {
+      if (sibling.nodeType === 3) {
+        isFlanked = regExp.test(sibling.nodeValue);
+      } else if (sibling.nodeType === 1 && !isBlock(sibling)) {
+        isFlanked = regExp.test(sibling.textContent);
+      }
+    }
+    return isFlanked
+  }
+
+  var reduce = Array.prototype.reduce;
+  var leadingNewLinesRegExp = /^\n*/;
+  var trailingNewLinesRegExp = /\n*$/;
+  var escapes = [
+    [/\\/g, '\\\\'],
+    [/\*/g, '\\*'],
+    [/^-/g, '\\-'],
+    [/^\+ /g, '\\+ '],
+    [/^(=+)/g, '\\$1'],
+    [/^(#{1,6}) /g, '\\$1 '],
+    [/`/g, '\\`'],
+    [/^~~~/g, '\\~~~'],
+    [/\[/g, '\\['],
+    [/\]/g, '\\]'],
+    [/^>/g, '\\>'],
+    [/_/g, '\\_'],
+    [/^(\d+)\. /g, '$1\\. ']
+  ];
+
+  function TurndownService (options) {
+    if (!(this instanceof TurndownService)) return new TurndownService(options)
+
+    var defaults = {
+      rules: rules,
+      headingStyle: 'setext',
+      hr: '* * *',
+      bulletListMarker: '*',
+      codeBlockStyle: 'indented',
+      fence: '```',
+      emDelimiter: '_',
+      strongDelimiter: '**',
+      linkStyle: 'inlined',
+      linkReferenceStyle: 'full',
+      br: '  ',
+      blankReplacement: function (content, node) {
+        return node.isBlock ? '\n\n' : ''
+      },
+      keepReplacement: function (content, node) {
+        return node.isBlock ? '\n\n' + node.outerHTML + '\n\n' : node.outerHTML
+      },
+      defaultReplacement: function (content, node) {
+        return node.isBlock ? '\n\n' + content + '\n\n' : content
+      }
+    };
+    this.options = extend({}, defaults, options);
+    this.rules = new Rules(this.options);
+  }
+
+  TurndownService.prototype = {
+    /**
+     * The entry point for converting a string or DOM node to Markdown
+     * @public
+     * @param {String|HTMLElement} input The string or DOM node to convert
+     * @returns A Markdown representation of the input
+     * @type String
+     */
+
+    turndown: function (input) {
+      if (!canConvert(input)) {
+        throw new TypeError(
+          input + ' is not a string, or an element/document/fragment node.'
+        )
+      }
+
+      if (input === '') return ''
+
+      var output = process.call(this, new RootNode(input));
+      return postProcess.call(this, output)
+    },
+
+    /**
+     * Add one or more plugins
+     * @public
+     * @param {Function|Array} plugin The plugin or array of plugins to add
+     * @returns The Turndown instance for chaining
+     * @type Object
+     */
+
+    use: function (plugin) {
+      if (Array.isArray(plugin)) {
+        for (var i = 0; i < plugin.length; i++) this.use(plugin[i]);
+      } else if (typeof plugin === 'function') {
+        plugin(this);
+      } else {
+        throw new TypeError('plugin must be a Function or an Array of Functions')
+      }
+      return this
+    },
+
+    /**
+     * Adds a rule
+     * @public
+     * @param {String} key The unique key of the rule
+     * @param {Object} rule The rule
+     * @returns The Turndown instance for chaining
+     * @type Object
+     */
+
+    addRule: function (key, rule) {
+      this.rules.add(key, rule);
+      return this
+    },
+
+    /**
+     * Keep a node (as HTML) that matches the filter
+     * @public
+     * @param {String|Array|Function} filter The unique key of the rule
+     * @returns The Turndown instance for chaining
+     * @type Object
+     */
+
+    keep: function (filter) {
+      this.rules.keep(filter);
+      return this
+    },
+
+    /**
+     * Remove a node that matches the filter
+     * @public
+     * @param {String|Array|Function} filter The unique key of the rule
+     * @returns The Turndown instance for chaining
+     * @type Object
+     */
+
+    remove: function (filter) {
+      this.rules.remove(filter);
+      return this
+    },
+
+    /**
+     * Escapes Markdown syntax
+     * @public
+     * @param {String} string The string to escape
+     * @returns A string with Markdown syntax escaped
+     * @type String
+     */
+
+    escape: function (string) {
+      return escapes.reduce(function (accumulator, escape) {
+        return accumulator.replace(escape[0], escape[1])
+      }, string)
+    }
+  };
+
+  /**
+   * Reduces a DOM node down to its Markdown string equivalent
+   * @private
+   * @param {HTMLElement} parentNode The node to convert
+   * @returns A Markdown representation of the node
+   * @type String
+   */
+
+  function process (parentNode) {
+    var self = this;
+    return reduce.call(parentNode.childNodes, function (output, node) {
+      node = new Node(node);
+
+      var replacement = '';
+      if (node.nodeType === 3) {
+        replacement = node.isCode ? node.nodeValue : self.escape(node.nodeValue);
+      } else if (node.nodeType === 1) {
+        replacement = replacementForNode.call(self, node);
+      }
+
+      return join(output, replacement)
+    }, '')
+  }
+
+  /**
+   * Appends strings as each rule requires and trims the output
+   * @private
+   * @param {String} output The conversion output
+   * @returns A trimmed version of the ouput
+   * @type String
+   */
+
+  function postProcess (output) {
+    var self = this;
+    this.rules.forEach(function (rule) {
+      if (typeof rule.append === 'function') {
+        output = join(output, rule.append(self.options));
+      }
+    });
+
+    return output.replace(/^[\t\r\n]+/, '').replace(/[\t\r\n\s]+$/, '')
+  }
+
+  /**
+   * Converts an element node to its Markdown equivalent
+   * @private
+   * @param {HTMLElement} node The node to convert
+   * @returns A Markdown representation of the node
+   * @type String
+   */
+
+  function replacementForNode (node) {
+    var rule = this.rules.forNode(node);
+    var content = process.call(this, node);
+    var whitespace = node.flankingWhitespace;
+    if (whitespace.leading || whitespace.trailing) content = content.trim();
+    return (
+      whitespace.leading +
+      rule.replacement(content, node, this.options) +
+      whitespace.trailing
+    )
+  }
+
+  /**
+   * Determines the new lines between the current output and the replacement
+   * @private
+   * @param {String} output The current conversion output
+   * @param {String} replacement The string to append to the output
+   * @returns The whitespace to separate the current output and the replacement
+   * @type String
+   */
+
+  function separatingNewlines (output, replacement) {
+    var newlines = [
+      output.match(trailingNewLinesRegExp)[0],
+      replacement.match(leadingNewLinesRegExp)[0]
+    ].sort();
+    var maxNewlines = newlines[newlines.length - 1];
+    return maxNewlines.length < 2 ? maxNewlines : '\n\n'
+  }
+
+  function join (string1, string2) {
+    var separator = separatingNewlines(string1, string2);
+
+    // Remove trailing/leading newlines and replace with separator
+    string1 = string1.replace(trailingNewLinesRegExp, '');
+    string2 = string2.replace(leadingNewLinesRegExp, '');
+
+    return string1 + separator + string2
+  }
+
+  /**
+   * Determines whether an input can be converted
+   * @private
+   * @param {String|HTMLElement} input Describe this parameter
+   * @returns Describe what it returns
+   * @type String|Object|Array|Boolean|Number
+   */
+
+  function canConvert (input) {
+    return (
+      input != null && (
+        typeof input === 'string' ||
+        (input.nodeType && (
+          input.nodeType === 1 || input.nodeType === 9 || input.nodeType === 11
+        ))
+      )
+    )
+  }
+
+  var service = new TurndownService({
+    bulletListMarker: '-',
+    listIndent: '   ',
+    // 3 spaces
+    blankReplacement: function blankReplacement(content, node) {
+      if (node.isBlock) {
+        return '\n\n';
+      } // This fixes an issue with turndown where an element with a space
+      // inside can be removed causing a jarring HTML coversion.
+
+
+      var hasWhitespace = /\s/.test(node.textContent);
+      var hasFlanking = node.flankingWhitespace.trailing || node.flankingWhitespace.leading;
+      return hasWhitespace && !hasFlanking ? ' ' : '';
+    }
+  }); // define all the elements we want stripped from output
+
+  var elementsToRemove = ['title', 'script', 'noscript', 'style', 'video', 'audio', 'object', 'iframe'];
+
+  for (var _i = 0, _elementsToRemove = elementsToRemove; _i < _elementsToRemove.length; _i++) {
+    var element = _elementsToRemove[_i];
+    service.remove(element);
+  } // As a user may have pasted markdown we rather crudley
+  // stop all escaping
+
+
+  service.escape = function (string) {
+    return string;
+  }; // turndown keeps title attribute attributes of links by default which isn't
+  // what is expected in govspeak
+
+
+  service.addRule('link', {
+    filter: function filter(node) {
+      return node.nodeName.toLowerCase() === 'a' && node.getAttribute('href');
+    },
+    replacement: function replacement(content, node) {
+      if (content.trim() === '') {
+        return '';
+      } else {
+        return "[".concat(content, "](").concat(node.getAttribute('href'), ")");
+      }
+    }
+  });
+  service.addRule('abbr', {
+    filter: function filter(node) {
+      return node.nodeName.toLowerCase() === 'abbr' && node.getAttribute('title');
+    },
+    replacement: function replacement(content, node) {
+      this.references[content] = node.getAttribute('title');
+      return content;
+    },
+    references: {},
+    append: function append() {
+      if (Object.keys(this.references).length === 0) {
+        return '';
+      }
+
+      var references = '\n\n';
+
+      for (var abbr in this.references) {
+        references += "*[".concat(abbr, "]: ").concat(this.references[abbr], "\n");
+      }
+
+      this.references = {}; // reset after appending
+
+      return references;
+    }
+  }); // GOV.UK content authors are encouraged to only use h2 and h3 headers, this
+  // converts other headers to be one of these (except h6 which is converted
+  // to a paragraph
+
+  service.addRule('heading', {
+    filter: ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'],
+    replacement: function replacement(content, node) {
+      var prefix;
+      var number = node.nodeName.charAt(1);
+
+      if (number === '1' || number === '2') {
+        prefix = '## ';
+      } else if (number === '3' || number === '4' || number === '5') {
+        prefix = '### ';
+      } else {
+        prefix = '';
+      }
+
+      return "\n\n".concat(prefix).concat(content, "\n\n");
+    }
+  }); // remove images
+  // this needs to be set as a rule rather than remove as it's part of turndown
+  // commonmark rules that needs overriding
+
+  service.addRule('img', {
+    filter: ['img'],
+    replacement: function replacement() {
+      return '';
+    }
+  }); // remove bold
+
+  service.addRule('bold', {
+    filter: ['b', 'strong'],
+    replacement: function replacement(content) {
+      return content;
+    }
+  }); // remove italic
+
+  service.addRule('italic', {
+    filter: ['i', 'em'],
+    replacement: function replacement(content) {
+      return content;
+    }
+  });
+  service.addRule('removeEmptyParagraphs', {
+    filter: function filter(node) {
+      return node.nodeName.toLowerCase() === 'p' && node.textContent.trim() === '';
+    },
+    replacement: function replacement() {
+      return '';
+    }
+  }); // strip paragraph elements within list items
+
+  service.addRule('stripParagraphsInListItems', {
+    filter: function filter(node) {
+      return node.nodeName.toLowerCase() === 'p' && node.parentNode.nodeName.toLowerCase() === 'li';
+    },
+    replacement: function replacement(content) {
+      return content;
+    }
+  });
+  service.addRule('cleanUpNestedLinks', {
+    filter: function filter(node) {
+      if (node.nodeName.toLowerCase() === 'a' && node.previousSibling) {
+        return node.previousSibling.textContent.match(/\]\($/);
+      }
+    },
+    replacement: function replacement(content, node) {
+      return node.getAttribute('href');
+    }
+  }); // Google docs has a habit of producing nested lists that are not nested
+  // with valid HTML. Rather than embedding sub lists inside an <li> element they
+  // are nested in the <ul> or <ol> element.
+
+  service.addRule('invalidNestedLists', {
+    filter: function filter(node) {
+      var nodeName = node.nodeName.toLowerCase();
+
+      if ((nodeName === 'ul' || nodeName === 'ol') && node.previousElementSibling) {
+        var previousNodeName = node.previousElementSibling.nodeName.toLowerCase();
+        return previousNodeName === 'li';
+      }
+    },
+    replacement: function replacement(content, node, options) {
+      content = content.replace(/^\n+/, '') // remove leading newlines
+      .replace(/\n+$/, '') // replace trailing newlines
+      .replace(/\n/gm, "\n".concat(options.listIndent)); // indent all nested content in the list
+      // indent this list to match sibling
+
+      return options.listIndent + content + '\n';
+    }
+  }); // This is ported from https://github.com/domchristie/turndown/blob/80297cebeae4b35c8d299b1741b383c74eddc7c1/src/commonmark-rules.js#L61-L80
+  // It is modified in the following ways:
+  // - Only determines ol ordering based on li elements
+  // - Removes handling of ol start attribute as this doesn't affect govspeak output
+  // - Makes spacing consistent with gov.uk markdown guidance
+
+  service.addRule('listItems', {
+    filter: 'li',
+    replacement: function replacement(content, node, options) {
+      content = content.replace(/^\n+/, '') // remove leading newlines
+      .replace(/\n+$/, '\n') // replace trailing newlines with just a single one
+      .replace(/\n/gm, "\n".concat(options.listIndent)); // indent all nested content in the list
+
+      var prefix = options.bulletListMarker + ' ';
+      var parent = node.parentNode;
+
+      if (parent.nodeName.toLowerCase() === 'ol') {
+        var listItems = Array.prototype.filter.call(parent.children, function (element) {
+          return element.nodeName.toLowerCase() === 'li';
+        });
+        var index = Array.prototype.indexOf.call(listItems, node);
+        prefix = (index + 1).toString() + '. ';
+      }
+
+      return prefix + content + (node.nextSibling && !/\n$/.test(content) ? '\n' : '');
+    }
+  });
+  service.addRule('removeMsWordCommentElements', {
+    filter: function filter(node) {
+      var nodeName = node.nodeName.toLowerCase();
+      var classList = node.classList;
+
+      if (nodeName === 'hr' && classList.contains('msocomoff')) {
+        return true;
+      }
+
+      if (nodeName === 'span' && classList.contains('MsoCommentReference')) {
+        return true;
+      }
+
+      if (nodeName === 'div' && classList.contains('msocomtxt')) {
+        return true;
+      }
+    },
+    replacement: function replacement() {
+      return '';
+    }
+  });
+  service.addRule('removeMsWordListBullets', {
+    filter: function filter(node) {
+      if (node.nodeName.toLowerCase() === 'span') {
+        var style = node.getAttribute('style');
+        return style ? style.match(/mso-list:ignore/i) : false;
+      }
+    },
+    replacement: function replacement() {
+      return '';
+    }
+  }); // Given a node it returns the Microsoft Word list level, returning undefined
+  // for an item that isn't a MS Word list node
+
+  function getMsWordListLevel(node) {
+    if (node.nodeName.toLowerCase() !== 'p') {
+      return;
+    }
+
+    var style = node.getAttribute('style');
+    var levelMatch = style && style.match(/mso-list/i) ? style.match(/level(\d+)/) : null;
+    return levelMatch ? parseInt(levelMatch[1], 10) : undefined;
+  }
+
+  function isMsWordListItem(node) {
+    return !!getMsWordListLevel(node);
+  } // Based on a node that is a list item in a MS Word document, this returns
+  // the marker for the list.
+
+
+  function msWordListMarker(node, bulletListMarker) {
+    var markerElement = node.querySelector('span[style="mso-list:Ignore"]'); // assume the presence of a period in a marker is an indicator of an
+    // ordered list
+
+    if (!markerElement || !markerElement.textContent.match(/\./)) {
+      return bulletListMarker;
+    }
+
+    var nodeLevel = getMsWordListLevel(node);
+    var item = 1;
+    var potentialListItem = node.previousElementSibling; // loop through previous siblings to count list items
+
+    while (potentialListItem) {
+      var itemLevel = getMsWordListLevel(potentialListItem); // if there are no more list items or we encounter the lists parent
+      // we don't need to count further
+
+      if (!itemLevel || itemLevel < nodeLevel) {
+        break;
+      } // if on same level increment the list items
+
+
+      if (nodeLevel === itemLevel) {
+        item += 1;
+      }
+
+      potentialListItem = potentialListItem.previousElementSibling;
+    }
+
+    return "".concat(item, ".");
+  }
+
+  service.addRule('addMsWordListItem', {
+    filter: function filter(node) {
+      return isMsWordListItem(node);
+    },
+    replacement: function replacement(content, node, options) {
+      var firstListItem = !node.previousElementSibling || !isMsWordListItem(node.previousElementSibling);
+      var prefix = firstListItem ? '\n\n' : ''; // we can determine the nesting of a list by a mso-list style attribute
+      // with a level
+
+      var nodeLevel = getMsWordListLevel(node);
+
+      for (var i = 1; i < nodeLevel; i++) {
+        prefix += options.listIndent;
+      }
+
+      var lastListItem = !node.nextElementSibling || !isMsWordListItem(node.nextElementSibling);
+      var suffix = lastListItem ? '\n\n' : '\n';
+      var listMarker = msWordListMarker(node, options.bulletListMarker);
+      return "".concat(prefix).concat(listMarker, " ").concat(content.trim()).concat(suffix);
+    }
+  }); // Remove links that have same href as link text and are the only content
+  // in a pasted document. This is because we assume here that they're trying
+  // to paste just a plain text URL.
+
+  service.addRule('removeAddressBarLinks', {
+    filter: function filter(node, options) {
+      if (node.nodeName.toLowerCase() !== 'a' || !node.getAttribute('href')) {
+        return;
+      }
+
+      var href = node.getAttribute('href').trim();
+      return href === node.textContent.trim() && href === node.ownerDocument.body.textContent.trim();
+    },
+    replacement: function replacement(content) {
+      return content;
+    }
+  });
+
+  function removeBrParagraphs(govspeak) {
+    // This finds places where we have a br in a paragraph on it's own and
+    // removes it.
+    //
+    // E.g. if we have HTML of <b><p>Text</p><br><p>More text</p></b> (as google
+    // docs can easily produce) which produces govspeak of
+    // "Text\n\n  \n\nMore Text". This regexp can strip this back to be
+    // Text\n\nMore Text
+    var regExp = new RegExp("\n(".concat(service.options.br, "\n)+\n?"), 'g');
+    return govspeak.replace(regExp, '\n');
+  }
+
+  function extractHeadingsFromLists(govspeak) {
+    // This finds instances of headings within ordered lists and replaces them
+    // with the headings only. This only applies to H2 and H3.
+    var headingsInListsRegExp = /\d\.\s(#{2,3})/g;
+    return govspeak.replace(headingsInListsRegExp, '$1');
+  }
+
+  function postProcess$1(govspeak) {
+    var govspeakWithExtractedHeadings = extractHeadingsFromLists(govspeak);
+    var brsRemoved = removeBrParagraphs(govspeakWithExtractedHeadings);
+    var whitespaceStripped = brsRemoved.trim();
+    return whitespaceStripped;
+  }
+
+  function htmlToGovspeak(html) {
+    var govspeak = service.turndown(html);
+    return postProcess$1(govspeak);
+  }
+
+  var browserSupportsTextareaTextNodes;
+  /**
+   * @param {HTMLElement} input
+   * @return {boolean}
+   */
+
+  function canManipulateViaTextNodes(input) {
+    if (input.nodeName !== "TEXTAREA") {
+      return false;
+    }
+
+    if (typeof browserSupportsTextareaTextNodes === "undefined") {
+      var textarea = document.createElement("textarea");
+      textarea.value = 1;
+      browserSupportsTextareaTextNodes = !!textarea.firstChild;
+    }
+
+    return browserSupportsTextareaTextNodes;
+  }
+  /**
+   * @param {HTMLTextAreaElement|HTMLInputElement} input
+   * @param {string} text
+   * @returns {void}
+   */
+
+
+  function index (input, text) {
+    // Most of the used APIs only work with the field selected
+    input.focus(); // IE 8-10
+
+    if (document.selection) {
+      var ieRange = document.selection.createRange();
+      ieRange.text = text; // Move cursor after the inserted text
+
+      ieRange.collapse(false
+      /* to the end */
+      );
+      ieRange.select();
+      return;
+    } // Webkit + Edge
+
+
+    var isSuccess = document.execCommand("insertText", false, text);
+
+    if (!isSuccess) {
+      var start = input.selectionStart;
+      var end = input.selectionEnd; // Firefox (non-standard method)
+
+      if (typeof input.setRangeText === "function") {
+        input.setRangeText(text);
+      } else {
+        // To make a change we just need a Range, not a Selection
+        var range = document.createRange();
+        var textNode = document.createTextNode(text);
+
+        if (canManipulateViaTextNodes(input)) {
+          var node = input.firstChild; // If textarea is empty, just insert the text
+
+          if (!node) {
+            input.appendChild(textNode);
+          } else {
+            // Otherwise we need to find a nodes for start and end
+            var offset = 0;
+            var startNode = null;
+            var endNode = null;
+
+            while (node && (startNode === null || endNode === null)) {
+              var nodeLength = node.nodeValue.length; // if start of the selection falls into current node
+
+              if (start >= offset && start <= offset + nodeLength) {
+                range.setStart(startNode = node, start - offset);
+              } // if end of the selection falls into current node
+
+
+              if (end >= offset && end <= offset + nodeLength) {
+                range.setEnd(endNode = node, end - offset);
+              }
+
+              offset += nodeLength;
+              node = node.nextSibling;
+            } // If there is some text selected, remove it as we should replace it
+
+
+            if (start !== end) {
+              range.deleteContents();
+            }
+          }
+        } // If the node is a textarea and the range doesn't span outside the element
+        //
+        // Get the commonAncestorContainer of the selected range and test its type
+        // If the node is of type `#text` it means that we're still working with text nodes within our textarea element
+        // otherwise, if it's of type `#document` for example it means our selection spans outside the textarea.
+
+
+        if (canManipulateViaTextNodes(input) && range.commonAncestorContainer.nodeName === "#text") {
+          // Finally insert a new node. The browser will automatically split start and end nodes into two if necessary
+          range.insertNode(textNode);
+        } else {
+          // If the node is not a textarea or the range spans outside a textarea the only way is to replace the whole value
+          var value = input.value;
+          input.value = value.slice(0, start) + text + value.slice(end);
+        }
+      } // Correct the cursor position to be at the end of the insertion
+
+
+      input.setSelectionRange(start + text.length, start + text.length); // Notify any possible listeners of the change
+
+      var e = document.createEvent("UIEvent");
+      e.initEvent("input", true, false);
+      input.dispatchEvent(e);
+    }
+  }
+
+  // This file provides a technique to maintain html that is pasted in legacy
+  // browsers, such as Internet Explorer that lack support for
+  // clipboardData.getData('text/html') on a paste event.
+  // This involves creating a hidden element, pasting into that, acessing the
+  // innerHTML of that element before finally removing it.
+  // This approach is explained more thoroughly in: https://www.lucidchart.com/techblog/2014/12/02/definitive-guide-copying-pasting-javascript/
+  function createHiddenElement() {
+    var hiddenElement = document.createElement('div');
+    hiddenElement.setAttribute('contenteditable', true);
+    hiddenElement.setAttribute('style', 'position: absolute; top:0; left: 0; opacity: 0;');
+    document.body.appendChild(hiddenElement);
+    return hiddenElement;
+  }
+
+  function removeElement(node) {
+    if (node.parentNode) {
+      node.parentNode.removeChild(node);
+    }
+  }
+
+  function getHtmlUsingHiddenElement(hiddenElement) {
+    hiddenElement.focus();
+    document.execCommand('paste');
+    return hiddenElement.innerHTML;
+  } // Check for write access to clipboard, otherwise we're not allowed by the browser to paste in a contenteditable container
+
+
+  function haveClipboardAccess() {
+    return window.clipboardData && window.clipboardData.setData('Text', '');
+  }
+
+  function legacyHtmlFromPaste() {
+    if (!haveClipboardAccess()) {
+      return false;
+    }
+
+    var hiddenElement = createHiddenElement();
+    var html = getHtmlUsingHiddenElement(hiddenElement);
+    removeElement(hiddenElement);
+    return html;
+  }
+
+  function htmlFromPasteEvent(event) {
+    // Modern browsers
+    if (event.clipboardData) {
+      return event.clipboardData.getData('text/html');
+    } else {
+      // IE doesn't support event.clipboardData, whereas it's supported by most
+      // other major browsers
+      return legacyHtmlFromPaste();
+    }
+  }
+
+  function textFromPasteEvent(event) {
+    if (event.clipboardData) {
+      return event.clipboardData.getData('text/plain');
+    } else if (window.clipboardData) {
+      return window.clipboardData.getData('Text');
+    }
+  }
+
+  function triggerPasteEvent(element, eventName, detail) {
+    var params = {
+      bubbles: false,
+      cancelable: false,
+      detail: detail || null
+    };
+    var event;
+
+    if (typeof window.CustomEvent === 'function') {
+      event = new window.CustomEvent(eventName, params);
+    } else {
+      event = document.createEvent('CustomEvent');
+      event.initCustomEvent(eventName, params.bubbles, params.cancelable, params.detail);
+    }
+
+    element.dispatchEvent(event);
+  }
+
+  function pasteListener(event) {
+    var element = event.target;
+    var html = htmlFromPasteEvent(event);
+    triggerPasteEvent(element, 'htmlpaste', html);
+    var text = textFromPasteEvent(event);
+    triggerPasteEvent(element, 'textpaste', text);
+
+    if (html && html.length) {
+      var govspeak = htmlToGovspeak(html);
+      triggerPasteEvent(element, 'govspeak', govspeak);
+      index(element, govspeak);
+      event.preventDefault();
+    }
+  }
+
+  exports.htmlToGovspeak = htmlToGovspeak;
+  exports.pasteListener = pasteListener;
+
+  Object.defineProperty(exports, '__esModule', { value: true });
+
+})));
+//# sourceMappingURL=paste-html-to-markdown.js.map

--- a/spec/features/converter_spec.rb
+++ b/spec/features/converter_spec.rb
@@ -4,7 +4,7 @@ RSpec.feature "Converting to Govspeak", type: :feature do
   scenario "User converts a Google Doc to Govspeak" do
     visit "/"
 
-    click_on "Convert Google Doc to Govspeak"
+    click_on "Convert Google Docs to Govspeak"
 
     attach_file "upload[file]", "./spec/support/fixtures/Sample Assessment Report.zip"
 

--- a/spec/features/govspeak_preview_spec.rb
+++ b/spec/features/govspeak_preview_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Govspeak Preview", type: :feature do
+RSpec.feature "Govspeak preview", type: :feature do
   scenario "Add Govspeak for one title" do
     visit "/"
 

--- a/spec/features/govspeak_preview_spec.rb
+++ b/spec/features/govspeak_preview_spec.rb
@@ -1,19 +1,49 @@
 require "rails_helper"
 
-RSpec.feature "Previews", type: :feature do
-  scenario "user clicks on 'some' styleguide example and sees example govspeak" do
+RSpec.feature "Govspeak Preview", type: :feature do
+  scenario "Add Govspeak for one title" do
     visit "/"
-    click_on "some"
 
-    expect(find("#govspeak_input").value).to start_with "^This is an information callout"
-  end
-
-  scenario "user clicks on 'Preview it' button and sees generated preview of Govspeak as HTML" do
-    visit "/"
-    click_on "some"
-
+    fill_in "govspeak_input", with: "## Ut viverra ante nunc, quis efficitur leo volutpat et"
     click_on "Preview"
 
-    expect(page).to have_content("This is an information callout")
+    expect(page).to have_css(".gem-c-govspeak.govuk-govspeak h2", text: "Ut viverra ante nunc, quis efficitur leo volutpat et")
+  end
+
+  scenario "Add Govspeak for one title and one paragraph" do
+    visit "/"
+
+    fill_in "govspeak_input", with: "## Lorem ipsum dolor sit amet, consectetur adipiscing elit
+      \n\nUt mattis augue sed nisl tincidunt, a laoreet lectus consequat. Mauris lacinia venenatis urna eu rhoncus."
+    click_on "Preview"
+
+    expect(page).to have_css(".gem-c-govspeak.govuk-govspeak h2", text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit")
+    expect(page).to have_css(".gem-c-govspeak.govuk-govspeak p", text: "Ut mattis augue sed nisl tincidunt, a laoreet lectus consequat. Mauris lacinia venenatis urna eu rhoncus.")
+  end
+
+  scenario "Add Govspeak for one paragraph and three list items" do
+    visit "/"
+
+    fill_in "govspeak_input", with: "Pellentesque ut facilisis eros, eget viverra nulla.
+      \n\n- Sed porta et nisi et tempus
+      \n- Nullam nec quam fringilla, imperdiet sem nec, feugiat urna. In hac habitasse platea dictumst
+      \n- Mauris egestas, turpis a lobortis fringilla, orci neque pellentesque tellus, a rutrum sem lorem ac nibh."
+    click_on "Preview"
+
+    expect(page).to have_css(".gem-c-govspeak.govuk-govspeak p", text: "Pellentesque ut facilisis eros, eget viverra nulla.")
+    expect(page).to have_css(".gem-c-govspeak.govuk-govspeak li", count: 3)
+    expect(page).to have_css(".gem-c-govspeak.govuk-govspeak li:nth-child(1)", text: "Sed porta et nisi et tempus")
+    expect(page).to have_css(".gem-c-govspeak.govuk-govspeak li:nth-child(2)", text: "Nullam nec quam fringilla, imperdiet sem nec, feugiat urna. In hac habitasse platea dictumst")
+    expect(page).to have_css(".gem-c-govspeak.govuk-govspeak li:nth-child(3)", text: "Mauris egestas, turpis a lobortis fringilla, orci neque pellentesque tellus, a rutrum sem lorem ac nibh.")
+  end
+
+  scenario "Add Govspeak for one paragraph and one link" do
+    visit "/"
+
+    fill_in "govspeak_input", with: "[Nulla finibus finibus hendrerit](https://www.lipsum.com/feed/html). In hac habitasse platea dictumst. Nam volutpat quam sed tellus ullamcorper ultrices. Maecenas hendrerit dolor lacus, sed commodo lectus sodales sed."
+    click_on "Preview"
+
+    expect(page).to have_css(".gem-c-govspeak.govuk-govspeak p", text: "Nulla finibus finibus hendrerit. In hac habitasse platea dictumst. Nam volutpat quam sed tellus ullamcorper ultrices. Maecenas hendrerit dolor lacus, sed commodo lectus sodales sed.")
+    expect(page).to have_link("Nulla finibus finibus hendrerit", href: "https://www.lipsum.com/feed/html")
   end
 end

--- a/spec/features/guide_spec.rb
+++ b/spec/features/guide_spec.rb
@@ -4,7 +4,7 @@ RSpec.feature "Govspeak guide", type: :feature do
   scenario "Govspeak guide renders markdown" do
     visit "/guide"
 
-    expect(page).to have_content("What is govspeak?")
+    expect(page).to have_content("What is Govspeak?")
     expect(page).to have_content("UK Parliament")
 
     expect(page).to have_css(".govuk-button.govuk-button--start")


### PR DESCRIPTION
## What
https://trello.com/c/EAYX1AbJ/776-update-govspeak-converter
https://govspeak-pre-include-fu-kdho9c.herokuapp.com/

- "Govspeak preview" changes to include functionality from https://alphagov.github.io/paste-html-to-govspeak/ to transform pasted rich text into Govspeak. The textarea and preview button has to:
  - convert pasted rich text into Govspeak markdown automatically and show the output when you click preview
  - allow you to paste and edit Govspeak markdown directly to the box and show the output when you click preview
- Update text on 'Govspeak Preview' page
- Update text on 'Govspeak Guide' page
- Update text on 'Convert Google doc to Govspeak' page

## Why
To make it easier for content publishers to generate Govspeak from pasted rich text content.

## Visual changes
<table role="table">
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td valign="top"><a target="_blank" rel="noopener noreferrer" href="https://user-images.githubusercontent.com/87758239/142277571-7c8e0c8d-52d3-44a2-91fc-7124b5f06c13.png"><img src="https://user-images.githubusercontent.com/87758239/142277571-7c8e0c8d-52d3-44a2-91fc-7124b5f06c13.png" width="360" style="max-width: 100%;"></a></td>
<td valign="top"><a target="_blank" rel="noopener noreferrer" href="https://user-images.githubusercontent.com/87758239/142277549-1341af4c-6024-4229-8066-cef84f57951d.png"><img src="https://user-images.githubusercontent.com/87758239/142277549-1341af4c-6024-4229-8066-cef84f57951d.png" width="360" style="max-width: 100%;"></a></td>
</tr>
<tr>
<td valign="top"><a target="_blank" rel="noopener noreferrer" href="https://user-images.githubusercontent.com/87758239/142277750-de3d9d8b-d531-4e60-a35a-da5d63774ddd.png"><img src="https://user-images.githubusercontent.com/87758239/142277750-de3d9d8b-d531-4e60-a35a-da5d63774ddd.png" width="360" style="max-width: 100%;"></a></td>
<td valign="top"><a target="_blank" rel="noopener noreferrer" href="https://user-images.githubusercontent.com/87758239/142277729-2b0443db-afc8-4e87-84fa-0a503f69ae7f.png"><img src="https://user-images.githubusercontent.com/87758239/142277729-2b0443db-afc8-4e87-84fa-0a503f69ae7f.png" width="360" style="max-width: 100%;"></a></td>
</tr>
</tbody>
</table>

## Anything else
This has been deployed to a review app - https://govspeak-pre-include-fu-kdho9c.herokuapp.com/ and will now be tested by some of the content publishers. It's possible there could be further change requests from testing.