### PR TITLE
Specify a lang attribute

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
   <title><%= yield(:title) %></title>
   <%= stylesheet_link_tag "application", :media => "all" %>

--- a/spec/features/guide_spec.rb
+++ b/spec/features/guide_spec.rb
@@ -1,6 +1,12 @@
 require "rails_helper"
 
 RSpec.feature "Govspeak guide", type: :feature do
+  scenario "Govspeak guide page specifies a language for the <html> element" do
+    visit "/guide"
+
+    expect(page).to have_selector("html[lang='en']")
+  end
+
   scenario "Govspeak guide renders markdown" do
     visit "/guide"
 


### PR DESCRIPTION
## What
https://trello.com/c/EAYX1AbJ/776-update-govspeak-converter

Specify a `lang` attribute. `<html>` element does not have a `[lang]` attribute.

https://govspeak-preview-pr-195.herokuapp.com/

## Why
If a page doesn't specify a `lang` attribute, a screen reader assumes that the page is in the default language that the user chose when setting up the screen reader. If the page isn't actually in the default language, then the screen reader might not announce the page's text correctly.

## Visual changes
<table role="table">
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td valign="top"><a target="_blank" rel="noopener noreferrer" href="https://user-images.githubusercontent.com/87758239/152147486-ba2df7c2-a1fa-4cfd-84ae-141d4b307f1c.png"><img src="https://user-images.githubusercontent.com/87758239/152147486-ba2df7c2-a1fa-4cfd-84ae-141d4b307f1c.png" width="360" style="max-width: 100%;"></a></td>
<td valign="top"><a target="_blank" rel="noopener noreferrer" href="https://user-images.githubusercontent.com/87758239/152147470-ed8e2c0f-5270-4e56-96cd-37c87bba9c54.png"><img src="https://user-images.githubusercontent.com/87758239/152147470-ed8e2c0f-5270-4e56-96cd-37c87bba9c54.png" width="360" style="max-width: 100%;"></a></td>
</tr>
</tbody>
</table>

## Anything else