### PR TITLE
Add associated label for upload a file form element

### DIFF
--- a/app/views/convert/index.html.erb
+++ b/app/views/convert/index.html.erb
@@ -34,6 +34,9 @@
 
   <%= form_tag({ action: :create }, multipart: true) do %>
     <%= render "govuk_publishing_components/components/file_upload", {
+      label: {
+        text: "Upload a file"
+      },
       name: "upload[file]"
     } %>
 


### PR DESCRIPTION
## What
https://trello.com/c/Ba67id7g/1040-fix-form-elements-do-not-have-associated-labels-govspeak-preview

Add associated label for upload a file form element.

## Why
Labels ensure that form controls are announced properly by assistive technologies, like screen readers.

## Visual changes
<table role="table">
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td valign="top"><a target="_blank" rel="noopener noreferrer" href="https://user-images.githubusercontent.com/87758239/152179086-cb5158ba-7d70-4d3d-8616-d1bda35d7c41.png"><img src="https://user-images.githubusercontent.com/87758239/152179086-cb5158ba-7d70-4d3d-8616-d1bda35d7c41.png" width="360" style="max-width: 100%;"></a></td>
<td valign="top"><a target="_blank" rel="noopener noreferrer" href="https://user-images.githubusercontent.com/87758239/152179098-886024f4-bea4-44fd-a8db-b4697c8b2df8.png"><img src="https://user-images.githubusercontent.com/87758239/152179098-886024f4-bea4-44fd-a8db-b4697c8b2df8.png" width="360" style="max-width: 100%;"></a></td>
</tr>
</tbody>
</table>