### PR TITLE
Fix error with stray end tag </a>

### DIFF
--- a/app/views/preview/new.html.erb
+++ b/app/views/preview/new.html.erb
@@ -25,7 +25,7 @@
     <li>email addresses</li>
   </ul>
 
-  <p class="govuk-body">You'll have to <a href="/guide" class="govuk-link">write additional Govspeak</a> separately. You cannot paste from a PDF</a>.</p>
+  <p class="govuk-body">You'll have to <a href="/guide" class="govuk-link">write additional Govspeak</a> separately. You cannot paste from a PDF.</p>
 
   <form method="post" action="/preview/">
     <%= render "govuk_publishing_components/components/textarea", {


### PR DESCRIPTION
## What
https://trello.com/c/5Ox8s3NO/1041-fix-error-stray-end-tag-a-govspeak-preview

Remove stray end tag `</a>`.

## Why
Fix HTML error - https://validator.w3.org/nu/?showoutline=yes&doc=https%3A%2F%2Fgovspeak-preview.herokuapp.com%2F

```
Error: Stray end tag </a>.
From line 85, column 145; to line 85, column 148 from a PDF</a>.</p>
```