### PR TITLE
Add skip-link

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,13 +6,15 @@
   <%= csrf_meta_tags %>
 </head>
 <body>
+  <%= render "govuk_publishing_components/components/skip_link", {
+  } %>
   <div id="wrapper">
     <%= render "govuk_publishing_components/components/layout_header", {
       environment: "beta",
       product_name: "Govspeak converter",
       navigation_items: navigation_items
     } %>
-    <main class="govuk-width-container">
+    <main id="main-content" class="govuk-width-container">
       <%= yield %>
     </main>
   </div>


### PR DESCRIPTION
## What

Adding [`skip_link`](https://components.publishing.service.gov.uk/component-guide/skip_link) to `govspeak-preview`

## Why

Highlighted as missing, allows a user to skip the menu items (accessibility)

## Visuals

![skip-link-on-page](https://user-images.githubusercontent.com/71266765/153639987-df13dc78-e7c7-43e0-80e3-86516e844593.png)