### PR TITLE
Add redirect when visiting herokuapp.com domain

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,8 @@
 Rails.application.routes.draw do
+  constraints(host: /govspeak-preview.herokuapp.com/) do
+    match "/(*path)" => redirect { |params, _req| "https://govspeak-preview.publishing.service.gov.uk/#{params[:path]}" }, via: %i[get post]
+  end
+
   resources :preview
   resources :convert, only: %w[index create]
   resources :guide


### PR DESCRIPTION
This app was previously hosted at govspeak-preview.herokuapp.com, but is [now at govspeak-preview.publishing.service.gov.uk](https://github.com/alphagov/govuk-dns-config/pull/788).

Since [Heroku maintains the previous domain](https://devcenter.heroku.com/articles/custom-domains#configuring-dns-for-subdomains), we need to implement a redirect to ensure all users only use the service at the new address.

This is not to be merged and deployed until https://github.com/alphagov/govuk-dns-config/pull/788 is deployed to both DNS providers.

[Trello card](https://trello.com/c/al645JXy/230-change-url-of-govspeak-and-govspeak-preview-application-to-show-they-are-a-govuk-service)