### PR TITLE
Update paste html to govspeak to v0.3.0

### DIFF
--- a/lib/assets/javascripts/paste-html-to-markdown.js
+++ b/lib/assets/javascripts/paste-html-to-markdown.js
@@ -973,18 +973,10 @@
   service.addRule('heading', {
     filter: ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'],
     replacement: function replacement(content, node) {
-      var prefix;
-      var number = node.nodeName.charAt(1);
-
-      if (number === '1' || number === '2') {
-        prefix = '## ';
-      } else if (number === '3' || number === '4' || number === '5') {
-        prefix = '### ';
-      } else {
-        prefix = '';
-      }
-
-      return "\n\n".concat(prefix).concat(content, "\n\n");
+      var headingLevel = parseInt(node.nodeName.charAt(1));
+      headingLevel = headingLevel === 1 ? 2 : headingLevel;
+      var prefix = Array(headingLevel + 1).join('#');
+      return "\n\n".concat(prefix, " ").concat(content, "\n\n");
     }
   }); // remove images
   // this needs to be set as a rule rather than remove as it's part of turndown


### PR DESCRIPTION
This update will allow paste events to retain the heading levels from level h2 to h6.

Up to H6 is supported by govspeak and this makes thing more accessible

Note: This needs to be moved to be installed via package.json

https://trello.com/c/aWGmHS2s/573-allow-h4s-to-h6s-with-paste-to-govspeak-converter