### PR TITLE
Add Licence reference in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,7 @@ It's hosted on [Heroku](http://govspeak-preview.herokuapp.com/), and automatical
 ```
 ./startup.sh --live
 ```
+
+## Licence
+
+[MIT License](LICENCE)


### PR DESCRIPTION
We want to make the reference to the licence in the README consistent with the GDS Way.

Trello card: https://trello.com/c/P0DpFcwW/260-standardise-all-license-files-names-to-licence