### PR TITLE
Set ruby-version in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source "https://rubygems.org"
+ruby File.read(".ruby-version")
 
 gem "rails", "7.0.6"
 


### PR DESCRIPTION
Heroku uses the Gemfile as the means to specify which Ruby version is used. Currently this app is failing to deploy to Heroku as it is trying to use Ruby 2.7.5 due to this information missing:

```
-----> Using Ruby version: ruby-2.7.5
-----> Installing dependencies using bundler 2.3.25
       Running: BUNDLE_WITHOUT='development:test' BUNDLE_PATH=vendor/bundle BUNDLE_BIN=vendor/bundle/bin BUNDLE_DEPLOYMENT=1 bundle install -j4
       Fetching gem metadata from https://rubygems.org/.........
       opentelemetry-registry-0.3.0 requires ruby version >= 3.0, which is incompatible
       with the current version, 2.7.5
       Bundler Output: Fetching gem metadata from https://rubygems.org/.........
       opentelemetry-registry-0.3.0 requires ruby version >= 3.0, which is incompatible
       with the current version, 2.7.5
```

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs. 
