### PR TITLE
Add name for CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,5 @@
+name: CI
+
 on: [push, pull_request]
 jobs:
   snyk-security:


### PR DESCRIPTION
Internal dependencies are not being auto-merged, despite adding the configuration for GOV.UK Dependabot Merger (#442).

This is because GOV.UK Dependabot Merger looks for a workflow with the name "CI" [2]. When name is absent, GitHub uses the workflow file path relative to the root of the repository instead.

Add the name for the CI workflow.

[1]: #442
[2]: https://github.com/alphagov/govuk-dependabot-merger/blob/3206c703b2b4cf2dedef751313b3407485e89471/lib/pull_request.rb#L179

---

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs. 
