### PR TITLE
Fix missing escapes in regex.

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  constraints(host: /govspeak-preview.herokuapp.com/) do
+  constraints(host: /govspeak-preview\.herokuapp\.com/) do
     match "/(*path)" => redirect { |params, _req| "https://govspeak-preview.publishing.service.gov.uk/#{params[:path]}" }, via: %i[get post]
   end
 


### PR DESCRIPTION
Not a real issue, but it shuts up CodeQL while being slightly more correct and only slightly less readable.

Resolves https://github.com/alphagov/govspeak-preview/security/code-scanning/2 (not an actual security issue).