### PR TITLE
Add Brakeman scan to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,16 @@ jobs:
   dependency-review:
     name: Dependency Review scan
     uses: alphagov/govuk-infrastructure/.github/workflows/dependency-review.yml@main
-  
+
+  security-analysis:
+    name: Security Analysis
+    uses: alphagov/govuk-infrastructure/.github/workflows/brakeman.yml@main
+    secrets: inherit
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+
   test:
     runs-on: ubuntu-latest
     env:

--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem "uglifier"
 
 group :development, :test do
   gem "capybara"
+  gem "govuk_test"
   gem "listen"
   gem "rspec-rails"
   gem "rubocop-govuk"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,6 +80,8 @@ GEM
     ast (2.4.2)
     base64 (0.2.0)
     bigdecimal (3.1.8)
+    brakeman (6.1.2)
+      racc
     builder (3.2.4)
     capybara (3.40.0)
       addressable
@@ -144,6 +146,11 @@ GEM
       rouge
       sprockets (>= 3)
       sprockets-rails
+    govuk_test (4.1.0)
+      brakeman (>= 5.0.2)
+      capybara (>= 3.36)
+      puma
+      selenium-webdriver (>= 4.0)
     hashdiff (1.1.0)
     htmlentities (4.3.4)
     i18n (1.14.5)
@@ -535,6 +542,11 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
+    selenium-webdriver (4.21.1)
+      base64 (~> 0.2)
+      rexml (~> 3.2, >= 3.2.5)
+      rubyzip (>= 1.2.2, < 3.0)
+      websocket (~> 1.0)
     sentry-rails (5.17.3)
       railties (>= 5.0)
       sentry-ruby (~> 5.17.3)
@@ -564,6 +576,7 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
+    websocket (1.2.10)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -581,6 +594,7 @@ DEPENDENCIES
   capybara
   govspeak
   govuk_publishing_components
+  govuk_test
   listen
   puma
   rails (= 7.1.3.4)
@@ -594,7 +608,7 @@ DEPENDENCIES
   webmock
 
 RUBY VERSION
-   ruby 3.3.0p0
+   ruby 3.3.1p55
 
 BUNDLED WITH
    2.3.22


### PR DESCRIPTION
We received an alert in Slack from Angry CI Robot prompting us to check we have [SCA][1], [SAST][2], and [Brakeman][3] scans in our CI pipeline for this app. We were missing the Brakeman scan

[1]: https://docs.publishing.service.gov.uk/manual/dependency-review.html
[2]: https://docs.publishing.service.gov.uk/manual/codeql.html
[3]: https://docs.publishing.service.gov.uk/manual/brakeman.html

---

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs. 
