### PR TITLE
Prepare for upgrade to govuk_publishing_components that uses GOV.UK Frontend V5.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem "reverse_markdown"
 gem "rubyzip"
 gem "sassc-rails"
 gem "sprockets-rails"
-gem "uglifier"
+gem "terser"
 
 group :development, :test do
   gem "capybara"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,7 +102,7 @@ GEM
     diff-lcs (1.5.1)
     drb (2.2.1)
     erubi (1.13.0)
-    execjs (2.8.1)
+    execjs (2.9.1)
     ffi (1.16.3)
     globalid (1.2.1)
       activesupport (>= 6.1)
@@ -562,13 +562,13 @@ GEM
     statsd-ruby (1.5.0)
     stringio (3.1.1)
     strscan (3.1.0)
+    terser (1.2.3)
+      execjs (>= 0.3.0, < 3)
     thor (1.3.1)
     tilt (2.0.10)
     timeout (0.4.1)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    uglifier (4.2.0)
-      execjs (>= 0.3.0, < 3)
     unicode-display_width (2.5.0)
     webmock (3.23.1)
       addressable (>= 2.8.0)
@@ -603,7 +603,7 @@ DEPENDENCIES
   rubyzip
   sassc-rails
   sprockets-rails
-  uglifier
+  terser
   webmock
 
 RUBY VERSION

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,3 +1,4 @@
 //= link_tree ../images
 //= link application.js
+//= link es6-components.js
 //= link application.css

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,6 +1,5 @@
 //= require govuk_publishing_components/dependencies
 //= require govuk_publishing_components/lib
-//= require govuk_publishing_components/components/button
 //= require govuk_publishing_components/components/govspeak
 
 //= require paste-html-to-markdown

--- a/app/assets/javascripts/es6-components.js
+++ b/app/assets/javascripts/es6-components.js
@@ -1,0 +1,10 @@
+// These modules from govuk_publishing_components
+// depend on govuk-frontend modules. govuk-frontend
+// now targets browsers that support `type="module"`.
+//
+// To gracefully prevent execution of these scripts
+// on browsers that don't support ES6, this script
+// should be included in a `type="module"` script tag
+// which will ensure they are never loaded.
+
+//= require govuk_publishing_components/components/button

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -21,5 +21,6 @@
     </main>
   </div>
   <%= javascript_include_tag "application" %>
+  <%= javascript_include_tag "es6-components", type: "module" %>
 </body>
 </html>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -30,6 +30,9 @@ Rails.application.configure do
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false
 
+  # Compress JavaScript
+  config.assets.js_compressor = :terser
+
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.asset_host = "http://assets.example.com"
 


### PR DESCRIPTION
I've followed the instructions for [Upgrading to GOV.UK Frontend v5 in the govuk_publishing_components gem](https://docs.google.com/document/d/1uwip7pzQwM7t5ghn9_8KrsWXLePSRUltFPZ5fYw6Ab8/edit). And, as predicted, this app didn't require many changes at all.

There's [an alternative version of this branch that includes the upgrade to the new gem](https://github.com/alphagov/govspeak-preview/pull/500) and that's currently deployed at https://govspeak-pre-upgrade-go-dpz17c.herokuapp.com/