### PR TITLE
[DO NOT MERGE] Prepare for upgrade to govuk_publishing_components that uses GOV.UK Frontend V5.1

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,3 +1,4 @@
 //= link_tree ../images
 //= link application.js
+//= link es6-components.js
 //= link application.css

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,6 +1,5 @@
 //= require govuk_publishing_components/dependencies
 //= require govuk_publishing_components/lib
-//= require govuk_publishing_components/components/button
 //= require govuk_publishing_components/components/govspeak
 
 //= require paste-html-to-markdown

--- a/app/assets/javascripts/es6-components.js
+++ b/app/assets/javascripts/es6-components.js
@@ -1,0 +1,10 @@
+// These modules from govuk_publishing_components
+// depend on govuk-frontend modules. govuk-frontend
+// now targets browsers that support `type="module"`.
+//
+// To gracefully prevent execution of these scripts
+// on browsers that don't support ES6, this script
+// should be included in a `type="module"` script tag
+// which will ensure they are never loaded.
+
+//= require govuk_publishing_components/components/button

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -21,5 +21,6 @@
     </main>
   </div>
   <%= javascript_include_tag "application" %>
+  <%= javascript_include_tag "es6-components", type: "module" %>
 </body>
 </html>


### PR DESCRIPTION
I've followed the instructions for [Upgrading to GOV.UK Frontend v5 in the govuk_publishing_components gem](https://docs.google.com/document/d/1uwip7pzQwM7t5ghn9_8KrsWXLePSRUltFPZ5fYw6Ab8/edit). And, as predicted, this app didn't require many changes at all.

It seems that this change shouldn't be merged into `main` until the new version of the gem is ready to upgrade to, hence the "DO NOT MERGE". (I missed that detail initially and merged [the first version of this pull request](https://github.com/alphagov/govspeak-preview/pull/499) and then had to [rollback the one commit that seemed to cause an issue](https://github.com/alphagov/govspeak-preview/pull/501/commits/ef6c866a37a9f26eb8f31c9ba5d9e5a32600d37f) 😊)

https://trello.com/c/hVsl7WSw/1239-upgrade-govukpublishingcomponents-for-govspeak-preview