### PR TITLE
Migrate to dart sass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@
 # Ignore all logfiles and tempfiles.
 /log/*.log
 /tmp
+
+/app/assets/builds/*
+!/app/assets/builds/.keep

--- a/Gemfile
+++ b/Gemfile
@@ -3,12 +3,12 @@ ruby File.read(".ruby-version")
 
 gem "rails", "7.1.3.4"
 
+gem "dartsass-rails"
 gem "govspeak"
 gem "govuk_publishing_components"
 gem "puma"
 gem "reverse_markdown"
 gem "rubyzip"
-gem "sassc-rails"
 gem "sprockets-rails"
 gem "terser"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,6 +98,9 @@ GEM
       bigdecimal
       rexml
     crass (1.0.6)
+    dartsass-rails (0.5.1)
+      railties (>= 6.0.0)
+      sass-embedded (~> 1.63)
     date (3.3.4)
     diff-lcs (1.5.1)
     drb (2.2.1)
@@ -533,14 +536,15 @@ GEM
     sanitize (6.1.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
-    sassc (2.4.0)
-      ffi (~> 1.9)
-    sassc-rails (2.1.2)
-      railties (>= 4.0.0)
-      sassc (>= 2.0)
-      sprockets (> 3.0)
-      sprockets-rails
-      tilt
+    sass-embedded (1.77.8)
+      google-protobuf (~> 4.26)
+      rake (>= 13)
+    sass-embedded (1.77.8-aarch64-linux-gnu)
+      google-protobuf (~> 4.26)
+    sass-embedded (1.77.8-arm64-darwin)
+      google-protobuf (~> 4.26)
+    sass-embedded (1.77.8-x86_64-linux-gnu)
+      google-protobuf (~> 4.26)
     selenium-webdriver (4.21.1)
       base64 (~> 0.2)
       rexml (~> 3.2, >= 3.2.5)
@@ -565,7 +569,6 @@ GEM
     terser (1.2.3)
       execjs (>= 0.3.0, < 3)
     thor (1.3.1)
-    tilt (2.0.10)
     timeout (0.4.1)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
@@ -591,6 +594,7 @@ PLATFORMS
 
 DEPENDENCIES
   capybara
+  dartsass-rails
   govspeak
   govuk_publishing_components
   govuk_test
@@ -601,7 +605,6 @@ DEPENDENCIES
   rspec-rails
   rubocop-govuk
   rubyzip
-  sassc-rails
   sprockets-rails
   terser
   webmock

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,0 +1,2 @@
+web: bin/rails server -p 3000
+css: bin/rails dartsass:watch

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,4 +1,4 @@
 //= link_tree ../images
 //= link application.js
 //= link es6-components.js
-//= link application.css
+//= link_tree ../builds

--- a/bin/dev
+++ b/bin/dev
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+
+if ! gem list foreman -i --silent; then
+  echo "Installing foreman..."
+  gem install foreman
+fi
+
+exec foreman start -f Procfile.dev "$@"

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -51,6 +51,9 @@ Rails.application.configure do
   # Suppress logger output for asset requests.
   config.assets.quiet = true
 
+  # To see the latest stylesheet changes, if running Sass in watch mode.
+  config.assets.digest = false
+
   # Raises error for missing translations.
   # config.i18n.raise_on_missing_translations = true
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -23,10 +23,6 @@ Rails.application.configure do
   # Enable static file serving from the `/public` folder (turn off if using NGINX/Apache for it).
   config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
 
-  # Rather than use a CSS compressor, use the SASS style to perform compression
-  config.sass.style = :compressed
-  config.sass.line_comments = false
-
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false
 

--- a/config/initializers/dartsass.rb
+++ b/config/initializers/dartsass.rb
@@ -1,0 +1,8 @@
+APP_STYLESHEETS = {
+  "application.scss" => "application.css",
+}.freeze
+
+all_stylesheets = APP_STYLESHEETS.merge(GovukPublishingComponents::Config.all_stylesheets)
+Rails.application.config.dartsass.builds = all_stylesheets
+
+Rails.application.config.dartsass.build_options << " --quiet-deps"

--- a/startup.sh
+++ b/startup.sh
@@ -5,7 +5,7 @@ bundle install
 if [[ $1 == "--live" ]] ; then
   GOVUK_APP_DOMAIN=www.gov.uk \
   GOVUK_WEBSITE_ROOT=https://www.gov.uk \
-  bundle exec rails s -p 3000
+  ./bin/dev
 else
-  bundle exec rails s -p 3000
+  ./bin/dev
 fi


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Migrate to dart sass from lib sass.

Relates to https://github.com/alphagov/govuk_publishing_components/pull/4106

## Why
All applications using `govuk_publishing_components` should be using dart sass, and some changes coming in that gem may cause errors if applications aren't using dart sass.

## Visual changes
None.

Trello card: https://trello.com/c/gW2NW1sB/239-fix-sass-compilation-warnings
