### PR TITLE
Fix Sass mixed declarations deprecations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,8 @@
 /log/*.log
 /tmp
 
+# Ignore compiled Rails assets
+/public/assets
+
 /app/assets/builds/*
 !/app/assets/builds/.keep

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -13,10 +13,10 @@ body {
 }
 
 .govspeak-preview-input {
-  @include govuk-font(19);
   background: govuk-colour("light-grey");
   padding: 2em;
   margin-top: govuk-spacing(4);
+  @include govuk-font(19);
 
   p {
     margin-bottom: govuk-spacing(3);
@@ -45,7 +45,6 @@ body {
 .govspeak-guide {
   .code-snippet + p,
   pre {
-    @include govuk-font(16);
     overflow: auto;
     max-width: 100%;
     position: relative;
@@ -55,8 +54,9 @@ body {
     border: 4px solid govuk-colour("light-grey");
     padding-top: 2.2em;
     margin: 0;
+    @include govuk-font(16);
 
-  &::before {
+    &::before {
       content: 'govspeak';
       position: absolute;
       left: 0;


### PR DESCRIPTION
[Trello](https://trello.com/c/OjtmJSVK/1359-fix-sass-deprecations-in-govspeak-preview)

Sass is changing the way it works with "declarations mixed with nested rules". We see the following deprecation warning when running `rails assets:precompile` or in the server logs when loading a page that uses affected Sass rules

```
Deprecation Warning: Sass's behavior for declarations that appear after nested
rules will be changing to match the behavior specified by CSS in an upcoming
version. To keep the existing behavior, move the declaration above the nested
rule. To opt into the new behavior, wrap the declaration in `& {}`.

More info: https://sass-lang.com/d/mixed-decls
```

The main thing we need to do is move a bunch of `@include`s below other declarations within rules, similar to what was done in govuk_publishing_components here: https://github.com/alphagov/govuk_publishing_components/commit/e65096e49785d37ed097a3247f110ef4c3173ae1

I've visually compared the site before and after updating and recompiling the stylesheets and hard refreshing the page, checking that components/elements using the affected rules look the same, and have included screenshots below

## Screenshots (no changes expected)

### Input font

#### Before

<img width="993" alt="Screenshot 2024-09-11 at 16 39 28" src="https://github.com/user-attachments/assets/0ab72a2f-a784-4495-828d-b1e0350bc7aa">

#### After

<img width="996" alt="Screenshot 2024-09-11 at 16 54 05" src="https://github.com/user-attachments/assets/7bd76f65-06d8-4074-8a52-91ca52e5445a">

### Code block

#### Before

<img width="939" alt="Screenshot 2024-09-11 at 16 52 23" src="https://github.com/user-attachments/assets/af4f42b2-a299-47a3-b2e2-9afbb046b27b">

#### After

<img width="940" alt="Screenshot 2024-09-11 at 16 53 36" src="https://github.com/user-attachments/assets/05afbd0d-79c6-4d50-8bd0-1c4dc5a6f7b2">

---

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs. 
