### PR TITLE
Add workflows for deploying to Kubernetes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,45 @@
+name: Deploy
+
+run-name: Deploy ${{ inputs.gitRef || github.event.release.tag_name  }} to ${{ inputs.environment || 'integration' }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      gitRef:
+        description: 'Commit, tag or branch name to deploy'
+        required: true
+        type: string
+      environment:
+        description: 'Environment to deploy to'
+        required: true
+        type: choice
+        options:
+        - integration
+        - staging
+        - production
+        default: 'integration'
+  release:
+    types: [released]
+
+jobs:
+  build-and-publish-image:
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'v')
+    name: Build and publish image
+    uses: alphagov/govuk-infrastructure/.github/workflows/build-and-push-multiarch-image.yml@main
+    with:
+      gitRef: ${{ inputs.gitRef || github.event.release.tag_name }}
+    permissions:
+      id-token: write
+      contents: read
+      packages: write
+  trigger-deploy:
+    name: Trigger deploy to ${{ inputs.environment || 'integration' }}
+    needs: build-and-publish-image
+    uses: alphagov/govuk-infrastructure/.github/workflows/deploy.yml@main
+    with:
+      imageTag: ${{ needs.build-and-publish-image.outputs.imageTag }}
+      environment: ${{ inputs.environment || 'integration' }}
+    secrets:
+      WEBHOOK_TOKEN: ${{ secrets.GOVUK_ARGO_EVENTS_WEBHOOK_TOKEN }}
+      WEBHOOK_URL: ${{ secrets.GOVUK_ARGO_EVENTS_WEBHOOK_URL }}
+      GH_TOKEN: ${{ secrets.GOVUK_CI_GITHUB_API_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,16 @@
+name: Release
+
+on:
+  workflow_dispatch:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+    branches: [main]
+
+jobs:
+  release:
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    name: Release
+    uses: alphagov/govuk-infrastructure/.github/workflows/release.yml@main
+    secrets:
+      GH_TOKEN: ${{ secrets.GOVUK_CI_GITHUB_API_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+ARG ruby_version=3.3
+ARG base_image=ghcr.io/alphagov/govuk-ruby-base:$ruby_version
+ARG builder_image=ghcr.io/alphagov/govuk-ruby-builder:$ruby_version
+
+
+FROM --platform=$TARGETPLATFORM $builder_image AS builder
+
+WORKDIR $APP_HOME
+COPY Gemfile* .ruby-version ./
+RUN bundle install
+COPY package.json yarn.lock ./
+RUN yarn install --immutable
+RUN bootsnap precompile --gemfile .
+RUN rails assets:precompile && rm -fr log
+
+
+FROM --platform=$TARGETPLATFORM $base_image
+
+ENV GOVUK_APP_NAME=govspeak-preview
+
+WORKDIR $APP_HOME
+COPY --from=builder $BUNDLE_PATH $BUNDLE_PATH
+COPY --from=builder $BOOTSNAP_CACHE_DIR $BOOTSNAP_CACHE_DIR
+COPY --from=builder $APP_HOME .
+
+USER app
+CMD ["puma"]

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source "https://rubygems.org"
 
 gem "rails", "7.2.1"
 
+gem "bootsnap", require: false
 gem "dartsass-rails"
 gem "govspeak"
 gem "govuk_publishing_components"

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,4 @@
 source "https://rubygems.org"
-ruby File.read(".ruby-version")
 
 gem "rails", "7.2.1"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,6 +76,8 @@ GEM
     ast (2.4.2)
     base64 (0.2.0)
     bigdecimal (3.1.8)
+    bootsnap (1.18.4)
+      msgpack (~> 1.2)
     brakeman (6.1.2)
       racc
     builder (3.3.0)
@@ -191,6 +193,7 @@ GEM
     mini_mime (1.1.5)
     mini_portile2 (2.8.7)
     minitest (5.25.1)
+    msgpack (1.7.3)
     net-imap (0.4.17)
       date
       net-protocol
@@ -591,6 +594,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  bootsnap
   capybara
   dartsass-rails
   govspeak

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -607,8 +607,5 @@ DEPENDENCIES
   terser
   webmock
 
-RUBY VERSION
-   ruby 3.3.1p55
-
 BUNDLED WITH
    2.3.22


### PR DESCRIPTION
This allows the application to be built as a Docker image, then released to our Kubernetes infrastructure, removing the need for the application to be hosted on Heroku.

PR was created by following [these instructions](https://docs.publishing.service.gov.uk/kubernetes/create-app/#allow-your-application-to-be-built-as-a-docker-image).

[Trello card](https://trello.com/c/dhgDqvBa)