### PR TITLE
Update assets precompile for EKS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,8 @@ WORKDIR $APP_HOME
 COPY Gemfile* .ruby-version ./
 RUN bundle install
 COPY package.json yarn.lock ./
-RUN yarn install --immutable
+RUN yarn install --production --frozen-lockfile --non-interactive --link-duplicates
+COPY . .
 RUN bootsnap precompile --gemfile .
 RUN rails assets:precompile && rm -fr log
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -36,6 +36,9 @@ module GovspeakPreview
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
 
+    # Path within public/ where assets are compiled to
+    config.assets.prefix = "/assets/govspeak-preview"
+
     # Using a sass css compressor causes a scss file to be processed twice (once
     # to build, once to compress) which breaks the usage of "unquote" to use
     # CSS that has same function names as SCSS such as max


### PR DESCRIPTION
Our EKS setup requires assets to be present in a specific directory, so updating the configuration to allow this.

Also adding a step that was missed from the Dockerfile that caused the asset precompiling to never start.

[Trello card](https://trello.com/c/dhgDqvBa)