### PR TITLE
Revert "Change CSRF protection mode to fix code scanning errors."

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,10 +1,3 @@
 class ApplicationController < ActionController::Base
-  protect_from_forgery with: :exception
-
-  rescue_from ActionController::InvalidAuthenticityToken do
-    render_error(
-      403,
-      body: "Invalid authenticity token",
-    )
-  end
+  protect_from_forgery
 end


### PR DESCRIPTION
Reverts alphagov/govspeak-preview#663

Resulted in errors due to my bad error handling, but also exposed other problems related to sentry