### PR TITLE
[PP-7224] Support locales in main previewer

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -127,7 +127,7 @@ GEM
       rake (>= 13)
     googleapis-common-protos-types (1.20.0)
       google-protobuf (>= 3.18, < 5.a)
-    govspeak (10.5.0)
+    govspeak (10.6.0)
       actionview (>= 6, < 8.0.3)
       addressable (>= 2.3.8, < 2.8.8)
       govuk_publishing_components (>= 43)
@@ -512,7 +512,7 @@ GEM
       nokogiri
     rexml (3.4.1)
     rinku (2.0.6)
-    rouge (4.5.2)
+    rouge (4.6.0)
     rspec-core (3.13.5)
       rspec-support (~> 3.13.0)
     rspec-expectations (3.13.5)

--- a/app/controllers/preview_controller.rb
+++ b/app/controllers/preview_controller.rb
@@ -1,7 +1,11 @@
 require "govspeak"
 
 class PreviewController < ApplicationController
+  include LocaleHelper
+
   def new
+    @options = locale_options
+
     if params[:styleguide]
       styleguides = YAML.safe_load(File.read(File.expand_path("lib/styleguides.yml"))).with_indifferent_access
       @govspeak_input = styleguides[params[:styleguide]]
@@ -11,7 +15,11 @@ class PreviewController < ApplicationController
   end
 
   def create
-    @govspeak_doc = Govspeak::Document.new(params[:govspeak])
+    @options = locale_options(selected: params[:locale])
+    @govspeak_doc = Govspeak::Document.new(
+      params[:govspeak],
+      { locale: params[:locale] },
+    )
     @govspeak_output = @govspeak_doc.to_html.html_safe
     @govspeak_input = params[:govspeak]
     render :new

--- a/app/helpers/locale_helper.rb
+++ b/app/helpers/locale_helper.rb
@@ -1,0 +1,12 @@
+module LocaleHelper
+private
+
+  def locale_options(selected: "en")
+    Govspeak::TranslationHelper.supported_locales.map { |locale|
+      value = locale[:code].to_s
+      text = value == "en" ? locale[:english_name] : "#{locale[:english_name]} (#{locale[:native_name]})"
+
+      { text:, value:, selected: value == selected }
+    }.sort_by { _1[:text] }
+  end
+end

--- a/app/views/preview/new.html.erb
+++ b/app/views/preview/new.html.erb
@@ -37,6 +37,12 @@
       value: @govspeak_input
     } %>
 
+    <%= render "govuk_publishing_components/components/select", {
+      id: "locale",
+      label: "Locale",
+      options: @options
+    } %>
+
     <%= render "govuk_publishing_components/components/button", {
       text: "Preview",
     } %>

--- a/spec/features/govspeak_preview_spec.rb
+++ b/spec/features/govspeak_preview_spec.rb
@@ -46,4 +46,21 @@ RSpec.feature "Govspeak preview", type: :feature do
     expect(page).to have_css(".gem-c-govspeak.govuk-govspeak p", text: "Nulla finibus finibus hendrerit. In hac habitasse platea dictumst. Nam volutpat quam sed tellus ullamcorper ultrices. Maecenas hendrerit dolor lacus, sed commodo lectus sodales sed.")
     expect(page).to have_link("Nulla finibus finibus hendrerit", href: "https://www.lipsum.com/feed/html")
   end
+
+  scenario "Add Govspeak with translatable component label using Welsh as the locale" do
+    visit "/"
+
+    fill_in "govspeak_input", with: <<~GOVSPEAK
+      Gellir ychwanegu troednodiadau[^1].
+
+      [^1]: Ac yna wedi'i ddiffinio'n ddiweddarach.
+    GOVSPEAK
+    select "Welsh (Cymraeg)", from: "locale"
+    click_on "Preview"
+
+    expect(page).to have_css(
+      ".gem-c-govspeak.govuk-govspeak a.footnote",
+      text: "[troednodyn 1]",
+    )
+  end
 end


### PR DESCRIPTION
This allows users to select a locale in the main previewer. The locale will be sent to Govspeak with appropriate static content (like component labels) translated where supported

Recording showing English translation of the 'footnote' label, then Welsh, then falling back to English when requesting a locale without a corresponding translation (Arabic) (note that the order of locales has changed since this recording to be alphabetical by English name, but still defaulting to English):

https://github.com/user-attachments/assets/0c8ff23a-c542-41e2-bb25-de09034aae66