### PR TITLE
Import styles for skip-link component

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -9,6 +9,7 @@
 @import "govuk_publishing_components/components/layout-header";
 @import "govuk_publishing_components/components/select";
 @import "govuk_publishing_components/components/service-navigation";
+@import "govuk_publishing_components/components/skip-link";
 @import "govuk_publishing_components/components/textarea";
 @import "govspeak-visual-editor/dist/style";
 


### PR DESCRIPTION
## What

Import styles for skip-link component

## Why

The styles for the skip-link component are currently imported in the layout-header component.

This import will be removed in a future release of the govuk_publishing_components gem to ensure the layout-header components only imports the styles it needs.

Adding this change in advance of the update to the gem will ensure the skip-link always renders correctly.

Further info: https://github.com/alphagov/govuk_publishing_components/pull/4985

---
This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs. 
