### PR TITLE
Disable Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,1 @@
-version: 2
-updates:
-  - package-ecosystem: bundler
-    directory: /
-    schedule:
-      interval: daily
-  - package-ecosystem: github-actions
-    directory: /
-    schedule:
-      interval: daily
+---


### PR DESCRIPTION
Disable Dependabot for all dependencies while the npmjs security incident is ongoing