### PR TITLE
[PP-7804] Show error on missing file in Google Doc converter

### DIFF
--- a/app/controllers/convert_controller.rb
+++ b/app/controllers/convert_controller.rb
@@ -2,7 +2,14 @@ class ConvertController < ApplicationController
   def index; end
 
   def create
-    @govspeak_input = GoogleDocsToGovspeak.new(params[:upload][:file]).to_govspeak
+    file = params.dig(:upload, :file)
+
+    if file.blank?
+      @error = "Choose a file to convert"
+      return render :index
+    end
+
+    @govspeak_input = GoogleDocsToGovspeak.new(file).to_govspeak
 
     if @govspeak_input
       # Preview the converted Govspeak

--- a/spec/features/converter_spec.rb
+++ b/spec/features/converter_spec.rb
@@ -13,6 +13,17 @@ RSpec.feature "Converting to Govspeak", type: :feature do
     expect(page).to have_content("GOV.UK Notify")
   end
 
+  scenario "User submits the form without uploading a file" do
+    visit "/"
+
+    click_on "Convert Google Docs to Govspeak"
+
+    click_on "Convert"
+
+    expect(page.status_code).to eq(200)
+    expect(page).to have_content("Choose a file to convert")
+  end
+
   scenario "User attempts to convert a Google Doc with images" do
     visit "/"
 


### PR DESCRIPTION
Submitting the convert form without choosing a file would previously call `[:file]` on a `nil` `params[:upload]`, raising a `NoMethodError` and returning a 500 to the user. This also logged to Sentry and alerted in Slack, creating noise for what is really user error

This guards against a missing file with `params.dig` and re-renders the form with a "Choose a file to convert" message. The view already renders `@error` via the `error_alert` component, so the user now sees a clear message instead of a 500

<img width="987" height="667" alt="Screenshot 2026-07-02 at 13 55 26" src="https://github.com/user-attachments/assets/27eb14ca-6866-476f-8cc0-910e52a80595" />