### PR TITLE
[PP-7812] Default to only allowing HTML responses across the app

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,9 @@
 class ApplicationController < ActionController::Base
+  before_action :allow_only_html_requests
+
   protect_from_forgery with: :exception
+
+  def allow_only_html_requests
+    head :not_acceptable unless request.format.html?
+  end
 end

--- a/spec/requests/convert_controller_spec.rb
+++ b/spec/requests/convert_controller_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe "ConvertController", type: :request do
+  describe "GET /convert" do
+    it "accepts HTML requests" do
+      get "/convert"
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "rejects non-HTML requests" do
+      get "/convert", headers: {
+        "Accept" => "application/json",
+      }
+      expect(response).to have_http_status(:not_acceptable)
+    end
+  end
+
+  describe "POST /convert" do
+    it "accepts HTML requests" do
+      post "/convert"
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "rejects non-HTML requests" do
+      post "/convert", headers: {
+        "Accept" => "application/json",
+      }
+      expect(response).to have_http_status(:not_acceptable)
+    end
+  end
+end

--- a/spec/requests/editor_controller_spec.rb
+++ b/spec/requests/editor_controller_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.describe "EditorController", type: :request do
+  describe "GET /editor" do
+    it "accepts HTML requests" do
+      get "/editor"
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "rejects non-HTML requests" do
+      get "/editor", headers: {
+        "Accept" => "application/json",
+      }
+      expect(response).to have_http_status(:not_acceptable)
+    end
+  end
+end

--- a/spec/requests/guide_controller_spec.rb
+++ b/spec/requests/guide_controller_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.describe "GuideController", type: :request do
+  describe "GET /guide" do
+    it "accepts HTML requests" do
+      get "/guide"
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "rejects non-HTML requests" do
+      get "/guide", headers: {
+        "Accept" => "application/json",
+      }
+      expect(response).to have_http_status(:not_acceptable)
+    end
+  end
+end

--- a/spec/requests/preview_controller_spec.rb
+++ b/spec/requests/preview_controller_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe "PreviewController", type: :request do
+  describe "GET /preview/new" do
+    it "accepts HTML requests" do
+      get "/preview/new"
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "rejects non-HTML requests" do
+      get "/preview/new", headers: {
+        "Accept" => "application/json",
+      }
+      expect(response).to have_http_status(:not_acceptable)
+    end
+  end
+
+  describe "POST /preview" do
+    it "accepts HTML requests" do
+      post "/preview"
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "rejects non-HTML requests" do
+      post "/preview", headers: {
+        "Accept" => "application/json",
+      }
+      expect(response).to have_http_status(:not_acceptable)
+    end
+  end
+end


### PR DESCRIPTION
We sometimes get Sentry alerts logged where requests are being made by security scans or malicious users with formats that are not HTML.

As this application does not support responses other than HTML, we get a `ActionView::MissingTemplate` error, which is logged to Sentry and the team alerted.

There is no action we can take on these alerts.

Therefore limiting the application to only HTML responses, with a more suitable error code (406 instead of 500) being returned to users and nothing logged to Sentry.

A similar fix was recently performed in the Frontend app: https://github.com/alphagov/frontend/pull/5561

The issue could be reproduced locally with:

```sh
curl -XPOST http://govspeak-preview.dev.gov.uk/preview -H "Accept: application/json" -H "Content-Type: application/x-www-form-urlencoded" -d "govspeak=Test"
```